### PR TITLE
Fixed warning about duplicate dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler</artifactId>
-      <version>1.203</version>
+      <version>1.233</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
@@ -77,11 +77,6 @@
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
       <version>1.1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke.stapler</groupId>
-      <artifactId>stapler</artifactId>
-      <version>1.233</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
Dependency on org.kohsuke.stapler:stapler was declared twice: on 1.203
and 1.233.
Kept the 1.233 after having checked with `mvn dependency:list` it was
actually the one being currently chosen by the maven resolution
strategy.