### PR TITLE
Update the container to use the official jetty image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM anapsix/alpine-java:jre8
+FROM jetty:jre8
 
-RUN adduser -D -h /home/accountapp accountapp
-ADD bin /home/accountapp/bin
-ADD build/libs/accountapp*.war /home/accountapp/bin/accountapp.war
+ADD build/libs/accountapp*.war /var/lib/jetty/webapps/account.war
+
+# This is apparently needed by Stapler for some weird reason. O_O
+RUN mkdir -p /home/jetty/.app
+
+RUN mkdir -p /etc/accountapp
 
 EXPOSE 8080
-USER accountapp
 
-ENTRYPOINT /home/accountapp/bin/run.sh
+# Overriding the CMD from our parent to make it easier to tell it about
+# our config.properties which the app needs
+CMD java -DCONFIG=/etc/accountapp/config.properties -jar "$JETTY_HOME/start.jar"

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ server, so the data you'll be seeing is real.
 For deploying to production, this app gets containerized. The container expects
 to see `/etc/accountapp` mounted from outside that contains the abovementioned
 `config.properties`
+
+
+To run the container locally, build it then:
+
+    docker run -ti --net=host  -v `pwd`:/etc/accountapp jenkinsciinfra/account-app:latest

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-cd "$(dirname "$0")"
-
-exec java -DCONFIG=/etc/accountapp/config.properties -jar jetty-runner*.jar \
-    --port 8080 \
-    --path /account \
-    accountapp.war

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,6 @@ repositories {
     maven { url 'https://repo.jenkins-ci.org/public' }
 }
 
-configurations {
-    /* Docker jars are additional components we should copy into the container
-     */
-    dockerJars
-}
-
 dependencies {
     compile 'javax.servlet:servlet-api:2.4'
 
@@ -41,8 +35,6 @@ dependencies {
     }
 
     testCompile 'junit:junit:[4.8.1,5.0)'
-
-    dockerJars 'org.mortbay.jetty:jetty-runner:[8.1.15,)'
 }
 
 jettyRun {
@@ -50,14 +42,6 @@ jettyRun {
     httpPort 8081
 }
 
-task copyRunner(type: Copy) {
-    description 'Grab the jetty-runner to execute our war in the container'
-    destinationDir = file('bin')
-    /* Only grab the jetty-runner jar */
-    from configurations.dockerJars.files.find { it.name.matches ~/jetty-runner-(.*).jar/ }
-}
-
-
 war {
-    dependsOn check, copyRunner
+    dependsOn check
 }


### PR DESCRIPTION
This makes things *much* more sane and easy to maintain, since we're just
grabbing the base image directly from the Jetty project.