### PR TITLE
Remove trailing space after password in email.

### DIFF
--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -469,7 +469,7 @@ public class Application {
          */
         public void mailPassword(String password) throws MessagingException {
             mail("Admin <admin@jenkins-ci.org>", mail, "Your access to Jenkins resources", "Your userid is " + id + "\n" +
-                "Your temporary password is " + password + " \n" +
+                "Your temporary password is " + password + "\n" +
                 "\n" +
                 "Please visit " + getUrl() + " and update your password and profile\n", "text/plain");
         }


### PR DESCRIPTION
Some mail clients will select it when copying, and users have problems signing in, not noticing it.