### PR TITLE
Configure account-app through env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
 FROM jetty:jre8-alpine
 
-ADD build/libs/accountapp*.war /var/lib/jetty/webapps/ROOT.war
-
 # This is apparently needed by Stapler for some weird reason. O_O
 RUN mkdir -p /home/jetty/.app
 
+COPY build/libs/accountapp*.war /var/lib/jetty/webapps/ROOT.war
+
 RUN mkdir -p /etc/accountapp
+COPY etc/config.properties /etc/accountapp/config.properties.example
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN \
+  chmod 0755 /entrypoint.sh &&\
+  chown -R jetty: /etc/accountapp
 
 EXPOSE 8080
 
+USER jetty
+
 # Overriding the ENTRYPOINT from our parent to make it easier to tell it about
 # our config.properties which the app needs
-ENTRYPOINT java -DCONFIG=/etc/accountapp/config.properties -Durl="$LDAP_URL" -Dpassword="$LDAP_PASSWORD" -Djira.username="$JIRA_USERNAME" -Djira.password="$JIRA_PASSWORD" -Djira.url="$JIRA_URL" -jar "$JETTY_HOME/start.jar"
+ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /home/jetty/.app
 COPY build/libs/accountapp*.war /var/lib/jetty/webapps/ROOT.war
 
 RUN mkdir -p /etc/accountapp
-COPY etc/config.properties /etc/accountapp/config.properties.example
+COPY config.properties.example /etc/accountapp/config.properties.example
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM jetty:jre8-alpine
 
+LABEL \
+  Description="Deploy Jenkins infra account app" \
+  Project="https://github.com/jenkins-infra/account-app" \
+  Maintainer="infra@lists.jenkins-ci.org"
+
 # This is apparently needed by Stapler for some weird reason. O_O
 RUN mkdir -p /home/jetty/.app
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gem 'serverspec'
+gem 'rspec'
+gem 'rspec-core'
+gem 'docker-api'
+gem 'excon'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    docker-api (1.33.2)
+      excon (>= 0.38.0)
+      json
+    excon (0.55.0)
+    json (2.0.3)
+    multi_json (1.12.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.1.0)
+    net-telnet (0.1.1)
+    rake (12.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    serverspec (2.38.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.53)
+    sfl (2.3)
+    specinfra (2.67.1)
+      net-scp
+      net-ssh (>= 2.7, < 5.0)
+      net-telnet
+      sfl
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docker-api
+  excon
+  rake
+  rspec
+  rspec-core
+  serverspec
+
+BUNDLED WITH
+   1.14.5

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,15 @@ node('docker') {
         }
     }
 
+   	stage('Test'){
+        timestamps{
+            docker.image('ruby:2.3').inside('-v /var/run/docker.sock:/var/run/docker.sock --group-add=982') {
+                sh 'bundle install'
+                sh 'rake test'
+            }
+        }
+    }
+
     def container
     stage('Prepare Container') {
         timestamps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ properties([
 node('docker') {
     stage('Build') {
         timestamps {
+            deleteDir()
             checkout scm
             docker.image('java:8').inside {
                 sh './gradlew --no-daemon --info war'

--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ to see `/etc/accountapp` mounted from outside that contains the abovementioned
 To run the container locally, build it then:
 
     docker run -ti --net=host  -v `pwd`:/etc/accountapp jenkinsciinfra/account-app:latest
+
+## Configuration
+Instead of mounting the configuration file from an external volume, 
+we may want to use environment variable.
+Those two options are mutually exclusive.
+
+* APP_URL 
+* CIRCUIT_BREAKER_FILE ('/etc/accountapp/circuitBreaker')
+* JIRA_PASSWORD
+* JIRA_URL
+* JIRA_USERNAME
+* LDAP_MANAGER_DN
+* LDAP_NEW_USER_BASE_DN
+* LDAP_PASSWORD
+* LDAP_URL
+* RECAPTCHA_PUBLIC_KEY
+* RECAPTCHA_PRIVATE_KEY
+* SMTP_SERVER

--- a/README.md
+++ b/README.md
@@ -58,3 +58,15 @@ Those two options are mutually exclusive.
 * RECAPTCHA_PUBLIC_KEY
 * RECAPTCHA_PRIVATE_KEY
 * SMTP_SERVER
+
+## Tests
+We can run basic tests
+
+Required:
+  ruby-2.2
+
+Run:
+```
+  bundle install
+  rake test
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,36 @@
+require 'docker'
+
+@image = "account-app:latest"
+
+# Define tasks
+#
+desc "Build Docker Image #{@image}"
+task :build do
+  Docker::Image.build_from_dir('.',{ 't' => @image}) do |v|
+    if (log = JSON.parse(v)) && log.has_key?("stream")
+      $stdout.puts log["stream"]
+    end
+  end
+end
+
+namespace :test do
+  desc "Run Dockerfile tests for #{@image}"
+  task :dockerfile do
+    sh "rspec spec/dockerfile.rb -f d -cb"
+  end
+
+  desc "Run Container tests for #{@image}"
+  task :container do
+    sh "rspec spec/container.rb -f d -cb"
+  end
+
+  task :all => ['dockerfile','containers']
+end
+
+desc "Install gem dependencies for tests"
+task :init do
+    sh "bundle install"
+end
+
+desc "Run all spec files"
+task :test => ["test:dockerfile","test:container"]

--- a/config.properties.example
+++ b/config.properties.example
@@ -1,0 +1,23 @@
+# This file configures the Jenkins project's accounts management application.
+#
+# See: <https://github.com/jenkins-infra/account-app>
+server=LDAP_URL 
+managerDN=LDAP_MANAGER_DN
+managerPassword=LDAP_PASSWORD
+
+newUserBaseDN=LDAP_NEW_USER_BASE_DN
+
+# Host which accountapp can use for sending out password reset and other emails
+smtpServer=SMTP_SERVER
+
+# recaptcha v2 keys from rtyler's google account
+recaptchaPublicKey=RECAPTCHA_PUBLIC_KEY
+recaptchaPrivateKey=RECAPTCHA_PRIVATE_KEY
+
+url=APP_URL
+
+# Create this file on the host machine in order to temporarily disable account
+# creation
+circuitBreakerFile=CIRCUIT_BREAKER_FILE
+
+# vim: ft=conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+accountapp:
+  build: .
+  environment: 
+    LDAP_URL: 'https://ldap'
+    LDAP_PASSWORD: 'ldap_password'
+    JIRA_USERNAME: 'jira_username'
+    JIRA_PASSWORD: 'jira_password'
+    JIRA_URL: 'https://jira_url'
+    SMTP_SERVER: 'https://smtp_server'
+    RECAPTCHA_PRIVATE_KEY: 'recaptcha_private_key'
+    RECAPTCHA_PUBLIC_KEY: 'recaptcha_public_key'
+    APP_URL: 'https://app_url'
+    LDAP_MANAGER_DN: 'ldap_manager_dn'
+    LDAP_NEW_USER_BASE_DN: 'ldap_new_user_base_dn'
+
+shell:
+  build: .
+  environment: 
+    LDAP_URL: 'https://ldap'
+    LDAP_PASSWORD: 'ldap_password'
+    JIRA_USERNAME: 'jira_username'
+    JIRA_PASSWORD: 'jira_password'
+    JIRA_URL: 'https://jira_url'
+    SMTP_SERVER: 'https://smtp_server'
+    RECAPTCHA_PRIVATE_KEY: 'recaptcha_private_key'
+    RECAPTCHA_PUBLIC_KEY: 'recaptcha_public_key'
+    APP_URL: 'https://app_url'
+    LDAP_MANAGER_DN: 'ldap_manager_dn'
+    LDAP_NEW_USER_BASE_DN: 'ldap_new_user_base_dn'
+  entrypoint: /bin/sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e 
+
+init_config_properties() {
+    : "${LDAP_URL:?Ldap url required}"
+    : "${LDAP_PASSWORD:?Ldap password required}"
+    : "${JIRA_USERNAME:?Jira user required}"
+    : "${JIRA_PASSWORD:?Jira password required}"
+    : "${JIRA_URL:? Jira url required}"
+
+    # /etc/accountapp/config.properties
+    : "${SMTP_SERVER:? SMTP Server required}"
+    : "${RECAPTCHA_PUBLIC_KEY:? Recaptcha private key}"
+    : "${RECAPTCHA_PRIVATE_KEY:? Recaptcha private key}"
+    : "${APP_URL:? Application url required}"
+    : "${LDAP_MANAGER_DN:? Require ldap manager_DN}"
+    : "${LDAP_NEW_USER_BASE_DN:? Require ldap new user base DN}"
+    : "${CIRCUIT_BREAKER_FILE:=/etc/accountapp/circuitBreaker}"
+
+
+    cp /etc/accountapp/config.properties.example /etc/accountapp/config.properties
+
+    # Using # as variable may / 
+    sed -i "s#SMTP_SERVER#$SMTP_SERVER#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_URL#$LDAP_URL#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_PASSWORD#$LDAP_PASSWORD#" /etc/accountapp/config.properties
+    sed -i "s#RECAPTCHA_PUBLIC_KEY#$RECAPTCHA_PUBLIC_KEY#" /etc/accountapp/config.properties
+    sed -i "s#RECAPTCHA_PRIVATE_KEY#$RECAPTCHA_PRIVATE_KEY#" /etc/accountapp/config.properties
+    sed -i "s#APP_URL#$APP_URL#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_MANAGER_DN#$LDAP_MANAGER_DN#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_NEW_USER_BASE_DN#$LDAP_NEW_USER_BASE_DN#" /etc/accountapp/config.properties
+    sed -i "s#CIRCUIT_BREAKER_FILE#$CIRCUIT_BREAKER_FILE#" /etc/accountapp/config.properties
+}
+
+if [ ! -f /etc/accountapp/config.properties ]; then
+    init_config_properties
+fi
+
+exec java -DCONFIG=/etc/accountapp/config.properties -Durl="$LDAP_URL" -Dpassword="$LDAP_PASSWORD" -Djira.username="$JIRA_USERNAME" -Djira.password="$JIRA_PASSWORD" -Djira.url="$JIRA_URL" -jar "$JETTY_HOME/start.jar"
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,4 +38,3 @@ if [ ! -f /etc/accountapp/config.properties ]; then
 fi
 
 exec java -DCONFIG=/etc/accountapp/config.properties -Durl="$LDAP_URL" -Dpassword="$LDAP_PASSWORD" -Djira.username="$JIRA_USERNAME" -Djira.password="$JIRA_PASSWORD" -Djira.url="$JIRA_URL" -jar "$JETTY_HOME/start.jar"
-

--- a/spec/container.rb
+++ b/spec/container.rb
@@ -1,0 +1,83 @@
+require "serverspec"
+require "docker"
+
+files=[
+  '/entrypoint.sh',
+  '/etc/accountapp/config.properties.example',
+  '/var/lib/jetty/webapps/ROOT.war'
+]
+
+directories=[
+    '/home/jetty/.app',
+    '/etc/accountapp',
+    '/var/lib/jetty/webapps/'
+]
+
+image="spec/accountapp_spec:latest"
+
+apks =[
+  'musl',
+  'busybox',
+  'zlib',
+  'apk-tools',
+  'java-cacerts',
+  'java-common',
+  'openjdk8-jre-lib',
+  'openjdk8-jre-base',
+  'openjdk8-jre',
+]
+
+forbidden_apks =[
+  'openjdk7-jre-base',
+  'openjdk7-jre-lib',
+  'openjdk7-jre',
+]
+
+describe "Container" do
+    before(:all) do
+       Docker.options[:read_timeout] = 100000
+       Docker.options[:write_timeout] = 100000
+       @image=Docker::Image.build_from_dir('.',{ 't' => image })
+       @container = Docker::Container.create(
+         'Image'      => image,
+         'Entrypoint' => ["sh", "-c", "tail -f /dev/null"],
+         'Env'        => [
+             "TERM=xterm"
+          ])
+       @container.start
+
+       set :os, family: :alpine
+       set :backend, :docker
+       set :docker_container, @container.id
+    end
+
+    after(:all) do
+        @container.kill
+        @container.delete(:force => true)
+        @image.remove(:force => true)
+    end
+    
+    directories.each do |name|
+      it "should have directory: #{name}" do
+        expect(file(name)).to be_a_directory
+      end
+    end
+
+    files.each do |name|
+      it "should have file: #{name}" do
+        expect(file(name)).to be_a_file
+      end
+    end
+
+    apks.each do |apk| 
+      it "should have #{apk} installed" do
+        expect(package(apk)).to be_installed.by('apk')
+      end
+    end
+
+    forbidden_apks.each do |apk| 
+      it "shouldn't have #{apk} installed" do
+        expect(package(apk)).not_to be_installed
+      end
+    end
+end

--- a/spec/dockerfile.rb
+++ b/spec/dockerfile.rb
@@ -1,0 +1,53 @@
+require "serverspec"
+require "docker"
+
+name='spec/accountapp:latest'
+
+describe "Dockerfile" do 
+  before (:all) do
+    Docker.options[:read_timeout] = 100000
+    Docker.options[:write_timeout] = 100000
+
+    @image=Docker::Image.build_from_dir('.',{ 't' => name })
+    set :os, family: :alpine
+    set :backend, :dockerfile
+    set :docker_image, @image.id
+  end
+
+  after (:all) do
+    @image.remove(:force => true)
+  end
+
+  it "should be define" do
+    expect(@image).not_to be_nil
+  end
+
+  it "should have /entrypoint.sh" do
+    expect(@image.json["Config"]["Entrypoint"]).to include("/entrypoint.sh")
+  end
+
+  it "should have a label Description defined" do
+    expect(@image.json["ContainerConfig"]["Labels"]["Description"]).not_to be_nil
+  end
+
+  it "should have a label Project defined" do
+    expect(@image.json["ContainerConfig"]["Labels"]["Project"]).to eq("https://github.com/jenkins-infra/account-app")
+  end
+
+  it "should have a label Maintainer defined" do
+    expect(@image.json["ContainerConfig"]["Labels"]["Maintainer"]).to eq("infra@lists.jenkins-ci.org")
+  end
+
+  it "should have env JETTY_HOME defined" do
+      expect(@image.json["ContainerConfig"]["Env"]).to include("JETTY_HOME=/usr/local/jetty")
+  end
+  it "should have env JAVA_HOME defined" do
+      expect(@image.json["ContainerConfig"]["Env"]).to include("JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk/jre")
+  end
+  it "should have port 8080 open" do
+    expect(@image.json["ContainerConfig"]["ExposedPorts"]["8080/tcp"]).not_to be_nil
+  end
+  it "should run as jetty user" do
+    expect(@image.json["ContainerConfig"]["User"]).to eq("jetty")
+  end
+end


### PR DESCRIPTION
This PR remove strong dependency on external volumes.
All configuration can be done through env variables
It simplifies application deployment in an environment like kubernetes

Anyway it still work the old way.
We do not generate /etc/config.properties if it's already mounted