### PR TITLE
Add application configuration through env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/jetty-runner*.jar
 .gradle/
 *.sw*
 build/
+.env

--- a/README.md
+++ b/README.md
@@ -29,14 +29,57 @@ server, so the data you'll be seeing is real.
 The command line system properties are for JIRA LDAP sync tool. JIRA user account you are providing has to have the system admin access to JIRA.
 TODO: feed this data from config.properties
 
+### Docker Compose
+A docker compose file can be used for testing purpose.
+
+_Require ssh tunnel to an ldap server and an WAR archive_
+
+* Create the file ```.env``` used by docker-compose to load configuration
+.env example
+```
+    LDAP_URL=server=ldap://localhost:9389/
+    LDAP_PASSWORD=<insert your ldap password>
+    JIRA_USERNAME=<insert your jira username>
+    JIRA_PASSWORD=<insert your jira password>
+    JIRA_URL=https://issues.jenkins-ci.org
+    SMTP_SERVER=localhost
+    RECAPTCHA_PRIVATE_KEY=recaptcha_private_key
+    RECAPTCHA_PUBLIC_KEY=recaptcha_public_key
+    APP_URL=http://localhost:8080/
+    LDAP_MANAGER_DN=cn=admin,dc=jenkins-ci,dc=org
+    LDAP_NEW_USER_BASE_DN=ou=people,dc=jenkins-ci,dc=org
+```
+* Run docker-compose 
+```docker-compose up --build accountapp```
 
 ## Packaging
 
 For deploying to production, this app gets containerized. The container expects
-to see `/etc/accountapp` mounted from outside that contains the abovementioned
+to see `/etc/accountapp` mounted from outside that contains the above mentioned
 `config.properties`
 
 
 To run the container locally, build it then:
 
     docker run -ti --net=host  -v `pwd`:/etc/accountapp jenkinsciinfra/account-app:latest
+
+## Configuration
+Instead of mounting the configuration file from an external volume,
+we may want to use environment variable.
+
+**Those two options are mutually exclusive.**
+
+```
+* APP_URL
+* CIRCUIT_BREAKER_FILE
+* JIRA_PASSWORD
+* JIRA_URL
+* JIRA_USERNAME
+* LDAP_MANAGER_DN
+* LDAP_NEW_USER_BASE_DN
+* LDAP_PASSWORD
+* LDAP_URL
+* RECAPTCHA_PUBLIC_KEY
+* RECAPTCHA_PRIVATE_KEY
+* SMTP_SERVER
+```

--- a/config.properties.example
+++ b/config.properties.example
@@ -1,0 +1,22 @@
+# This file configures the Jenkins project's accounts management application.
+#
+# See: <https://github.com/jenkins-infra/account-app>
+server=LDAP_URL 
+managerDN=LDAP_MANAGER_DN
+managerPassword=LDAP_PASSWORD
+
+newUserBaseDN=LDAP_NEW_USER_BASE_DN
+
+# Host which accountapp can use for sending out password reset and other emails
+smtpServer=SMTP_SERVER
+
+recaptchaPublicKey=RECAPTCHA_PUBLIC_KEY
+recaptchaPrivateKey=RECAPTCHA_PRIVATE_KEY
+
+url=APP_URL
+
+# Create this file on the host machine in order to temporarily disable account
+# creation
+circuitBreakerFile=CIRCUIT_BREAKER_FILE
+
+# vim: ft=conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  accountapp:
+    build: .
+    image: accountapp:latest
+    env_file: .env
+    network_mode: host
+    ports:
+      - '8080:8080'
+  shell:
+    build: .
+    image: accountapp:latest
+    env_file: .env
+    entrypoint: /bin/sh
+    network_mode: host

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e 
+
+init_config_properties() {
+    : "${LDAP_URL:?Ldap url required}"
+    : "${LDAP_PASSWORD:?Ldap password required}"
+    : "${JIRA_USERNAME:?Jira user required}"
+    : "${JIRA_PASSWORD:?Jira password required}"
+    : "${JIRA_URL:? Jira url required}"
+
+    # /etc/accountapp/config.properties
+    : "${SMTP_SERVER:? SMTP Server required}"
+    : "${RECAPTCHA_PUBLIC_KEY:? Recaptcha private key}"
+    : "${RECAPTCHA_PRIVATE_KEY:? Recaptcha private key}"
+    : "${APP_URL:? Application url required}"
+    : "${LDAP_MANAGER_DN:? Require ldap manager_DN}"
+    : "${LDAP_NEW_USER_BASE_DN:? Require ldap new user base DN}"
+    : "${CIRCUIT_BREAKER_FILE:? Require circuitBreaker file}"
+
+
+    cp /etc/accountapp/config.properties.example /etc/accountapp/config.properties
+
+    # Using # as variables may contain / 
+    sed -i "s#SMTP_SERVER#$SMTP_SERVER#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_URL#$LDAP_URL#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_PASSWORD#$LDAP_PASSWORD#" /etc/accountapp/config.properties
+    sed -i "s#RECAPTCHA_PUBLIC_KEY#$RECAPTCHA_PUBLIC_KEY#" /etc/accountapp/config.properties
+    sed -i "s#RECAPTCHA_PRIVATE_KEY#$RECAPTCHA_PRIVATE_KEY#" /etc/accountapp/config.properties
+    sed -i "s#APP_URL#$APP_URL#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_MANAGER_DN#$LDAP_MANAGER_DN#" /etc/accountapp/config.properties
+    sed -i "s#LDAP_NEW_USER_BASE_DN#$LDAP_NEW_USER_BASE_DN#" /etc/accountapp/config.properties
+    sed -i "s#CIRCUIT_BREAKER_FILE#$CIRCUIT_BREAKER_FILE#" /etc/accountapp/config.properties
+}
+
+if [ ! -f /etc/accountapp/config.properties ]; then
+    init_config_properties
+fi
+
+exec java -DCONFIG=/etc/accountapp/config.properties -Durl="$LDAP_URL" -Dpassword="$LDAP_PASSWORD" -Djira.username="$JIRA_USERNAME" -Djira.password="$JIRA_PASSWORD" -Djira.url="$JIRA_URL" -jar "$JETTY_HOME/start.jar"


### PR DESCRIPTION
This PR add an additional way to configure 'accountapp' trough environment variables that simplify deployment on kubernetes cluster.

I added a docker-compose file only for testing purpose.

! This PR doesn't take into account [#96](https://github.com/jenkins-infra/account-app/pull/96) as it is not up to date with master.