### PR TITLE
[INFRA-1347] Doesn't escape all html error message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV APP_URL=http://accounts.jenkins.io/
 
 EXPOSE 8080
 
-USER ROOT
+USER root
 
 # /home/jetty/.app is apparently needed by Stapler for some weird reason. O_O
 RUN mkdir -p /home/jetty/.app &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV APP_URL=http://accounts.jenkins.io/
 
 EXPOSE 8080
 
+USER ROOT
 
 # /home/jetty/.app is apparently needed by Stapler for some weird reason. O_O
 RUN mkdir -p /home/jetty/.app &&\

--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -243,7 +243,7 @@ public class Application {
                 "To allow this account to be created, click the following link:\n" +
                 getUrl() + "/admin/signup?userId=" + enc(userid) + "&firstName=" + enc(firstName) + "&lastName=" + enc(lastName) + "&email=" + enc(email) + "\n";
             mail("Admin <admin@jenkins-ci.org>", "jenkinsci-account-admins@googlegroups.com", "Rejection of a new account creation for " + firstName + " " + lastName, body, "text/plain");
-            throw new UserError(SPAM_MESSAGE);
+            throw new SystemError(SPAM_MESSAGE);
         }
 
         String password = createRecord(userid, firstName, lastName, email);

--- a/src/main/java/org/jenkinsci/account/SystemError.java
+++ b/src/main/java/org/jenkinsci/account/SystemError.java
@@ -1,5 +1,4 @@
 package org.jenkinsci.account;
-
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest;
@@ -9,13 +8,12 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 
 /**
- * Indicates a problem in the user given information.
- * Remark: Message are considered as untrusted and therefor are escaped.
- *
- * @author Kohsuke Kawaguchi
+ * Created by Olivier Vernin on 11/10/17.
+ * Indicate an error send from the system which contain trusted information (no xss vulnerability)
+ * and therefor doesn't need to be escaped
  */
-public class UserError extends RuntimeException implements HttpResponse {
-    public UserError(String message) {
+public class SystemError extends RuntimeException implements HttpResponse {
+    public SystemError(String message){
         super(message);
     }
 

--- a/src/main/resources/org/jenkinsci/account/SystemError/index.jelly
+++ b/src/main/resources/org/jenkinsci/account/SystemError/index.jelly
@@ -1,0 +1,7 @@
+<j:jelly xmlns:j="jelly:core" xmlns:t="/org/jenkinsci/account/taglib" xmlns:st="jelly:stapler">
+    <st:statusCode value="500" />
+    <t:layout title="Error">
+        <h1>Oops!</h1>
+        <p style="font-size:1.5em">${it.message}</p>
+    </t:layout>
+</j:jelly>


### PR DESCRIPTION
I don't know if it's the best way to solve this. 
To make it short, some java string may contain untrusted or trusted html  and I don't know if it's possible to disable html escaping at the java level 