### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ properties([
     pipelineTriggers([[$class:"SCMTrigger", scmpoll_spec:"H/15 * * * *"]]),
 ])
 
-node('docker') {
+node('docker&&linux') {
     stage('Build') {
         timestamps {
             checkout scm


### PR DESCRIPTION
When Windows docker agents are available, make sure we only run this on Linux docker agents