### PR TITLE
Send email notification when resetting passwords + minor fixes and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,15 @@
 *.iws
 target
 config.properties
-bin/jetty-runner*.jar
+bin
 .idea
 .gradle/
 *.sw*
 build/
 .env
 fake_data
+
+# IDE
+.classpath
+.project
+.settings

--- a/src/main/java/org/jenkinsci/account/AdminUI.java
+++ b/src/main/java/org/jenkinsci/account/AdminUI.java
@@ -4,6 +4,7 @@ import org.jenkinsci.account.Application.User;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.mail.MessagingException;
@@ -51,13 +52,14 @@ public class AdminUI {
     }
 
     @RequirePOST
-    public HttpResponse doPasswordReset(@QueryParameter String id) throws NamingException {
+    public HttpResponse doPasswordReset(@QueryParameter String id, @QueryParameter String reason) throws NamingException, MessagingException {
         LdapContext con = app.connect();
         try {
             User u = app.getUserById(id, con);
 
             String p = PasswordUtil.generateRandomPassword();
             u.modifyPassword(con, p);
+            u.mailPasswordReset(p, Stapler.getCurrentRequest().getRemoteUser(), reason);
 
             return HttpResponses.forwardToView(this,"newPassword.jelly").with("user",u).with("password",p);
         } finally {

--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -89,6 +89,7 @@ public class Application {
     // not exposing this to UI
     /*package*/ final CircuitBreaker circuitBreaker;
 
+    @CheckForNull
     private BoardElection boardElection;
 
     public Application(Parameters params) throws Exception {
@@ -586,7 +587,9 @@ public class Application {
         }
     }
 
-    public Boolean isElectionEnabled () { return boardElection.isElectionEnabled() ;}
+    public Boolean isElectionEnabled () { 
+        return boardElection != null && boardElection.isElectionEnabled();
+    }
 
     public @CheckForNull BoardElection getBoardElection() {
         return boardElection;

--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -3,7 +3,6 @@ package org.jenkinsci.account;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.net.InetAddresses;
-
 import com.captcha.botdetect.web.servlet.Captcha;
 
 import io.jenkins.backend.jiraldapsyncer.JiraLdapSyncer;
@@ -628,7 +627,10 @@ public class Application {
     }
 
     public AdminUI getAdmin() {
-        return getMyself().isAdmin() ? new AdminUI(this) : null;
+        if (!getMyself().isAdmin()) {
+            throw HttpResponses.forbidden();
+        }
+        return new AdminUI(this);
     }
 
     private static final Logger LOGGER = Logger.getLogger(Application.class.getName());

--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -460,7 +460,7 @@ public class Application {
         Session session;
         Properties props = new Properties(System.getProperties());
         props.put("mail.smtp.host",params.smtpServer());
-        if(params.smtpAuth()) {
+        if(params.smtpAuth() != null && params.smtpAuth()) {
             props.put("mail.smtp.auth", params.smtpAuth());
             props.put("mail.smtp.starttls.enable", true);
             props.put("mail.smtp.port", 587);

--- a/src/main/resources/org/jenkinsci/account/Application/index.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/index.jelly
@@ -3,7 +3,9 @@
   <t:layout title="Account self-service app">
     <p>
     You can create/manage your user account that you use for accessing
-    <a href="http://wiki.jenkins-ci.org/" target="_top">Wiki</a> and <a href="http://issues.jenkins-ci.org/" target="_top">JIRA</a>,
+    <a href="http://issues.jenkins-ci.org/" target="_top">Jenkins JIRA</a>,
+    <a href="https://ci.jenkins.io/" target="_top">ci.jenkins.io</a>,
+    VPN and other services within the <a href="https://www.jenkins.io/projects/infrastructure" target="_top">Jenkins Infrastructure</a>.
     </p>
 
     <div id="account-menu">


### PR DESCRIPTION
This change ensures that a user gets email notification when a password is reset from the Web UI form or from a REST API call. It also allows specifying a password reset reason which can be passed through UI or through a REST API.

Additional bugfixes:

* Prevent NullPointerException when board elections are not configured in settings (default to disabled)
* Prevent NullPointerException when SMTP auth flag is not set explicitly (`Boolean` FTM)
