### PR TITLE
Update jira url to issues.jenkins.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV STV_GIT_URL="https://github.com/louridas/stv.git"
 ENV ELECTION_LOGDIR=/var/log/accountapp/elections
 ENV CIRCUIT_BREAKER_FILE=/etc/accountapp/circuitBreaker.txt
 ENV SMTP_SERVER=localhost
-ENV JIRA_URL=https://issues.jenkins-ci.org
+ENV JIRA_URL=https://issues.jenkins.io
 ENV APP_URL=http://accounts.jenkins.io/
 ENV ELECTION_ENABLED=false
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ following:
 
 Finally, run the application with Jetty, then access `http://localhost:8080/`:
 
-    ./gradlew -Djira.url=https://issues.jenkins-ci.org/ -Djira.username=kohsuke -Djira.password=... -Durl=ldap://localhost:9389 -Dpassword=... jettyRun
+    ./gradlew -Djira.url=https://issues.jenkins.io/ -Djira.username=kohsuke -Djira.password=... -Durl=ldap://localhost:9389 -Dpassword=... jettyRun
 
 (As you can see above, this connects your test instance to the actual LDAP
 server, so the data you'll be seeing is real.
@@ -43,7 +43,7 @@ _Require ssh tunnel to an ldap server and an WAR archive_
     ELECTION_OPEN=1970/01/01
     JIRA_USERNAME=<insert your jira username>
     JIRA_PASSWORD=<insert your jira password>
-    JIRA_URL=https://issues.jenkins-ci.org
+    JIRA_URL=https://issues.jenkins.io
     LDAP_URL=server=ldap://localhost:9389/
     LDAP_PASSWORD=<insert your ldap password>
     LDAP_MANAGER_DN=cn=admin,dc=jenkins-ci,dc=org

--- a/env.sandbox
+++ b/env.sandbox
@@ -3,7 +3,7 @@ ELECTION_CANDIDATES=alice,bob,sam,tom,jame
 ELECTION_ENABLED=true
 JIRA_USERNAME=xxx
 JIRA_PASSWORD=xxx
-JIRA_URL=https://issues.jenkins-ci.org
+JIRA_URL=https://issues.jenkins.io
 LDAP_URL= ldap://ldap:389/
 LDAP_PASSWORD=s3cr3t
 LDAP_MANAGER_DN=cn=admin,dc=jenkins-ci,dc=org

--- a/src/main/resources/org/jenkinsci/account/Application/doneMail.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/doneMail.jelly
@@ -4,7 +4,7 @@
     <h1>Done!</h1>
     <p>
       Check your mail for the password.
-      You can login to <a href="http://wiki.jenkins-ci.org/" target="_top">Wiki</a> and <a href="http://issues.jenkins-ci.org/" target="_top">JIRA</a>,
+      You can login to <a href="http://wiki.jenkins-ci.org/" target="_top">Wiki</a> and <a href="http://issues.jenkins.io/" target="_top">JIRA</a>,
       with this username and password.
     </p>
   </t:layout>

--- a/src/main/resources/org/jenkinsci/account/Application/index.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/index.jelly
@@ -3,7 +3,7 @@
   <t:layout title="Account self-service app">
     <p>
     You can create/manage your user account that you use for accessing
-    <a href="http://issues.jenkins-ci.org/" target="_top">Jenkins JIRA</a>,
+    <a href="http://issues.jenkins.io/" target="_top">Jenkins JIRA</a>,
     <a href="https://ci.jenkins.io/" target="_top">ci.jenkins.io</a>,
     VPN and other services within the <a href="https://www.jenkins.io/projects/infrastructure" target="_top">Jenkins Infrastructure</a>.
     </p>

--- a/src/main/resources/org/jenkinsci/account/UserError/index.jelly
+++ b/src/main/resources/org/jenkinsci/account/UserError/index.jelly
@@ -5,7 +5,7 @@
     <h1>Oops!</h1>
     <p style="font-size:1.5em">${it.message}</p>
     <j:if test="${it.id != null}">
-      Please consider reporting this as an <a href="https://issues.jenkins-ci.org/projects/INFRA/issues/">issue in the Jenkins INFRA project</a>.
+      Please consider reporting this as an <a href="https://issues.jenkins.io/projects/INFRA/issues/">issue in the Jenkins INFRA project</a>.
       Please mention the following error ID in the ticket: ${it.id}
     </j:if>
   </t:layout>

--- a/src/main/resources/org/jenkinsci/account/taglib/layout.jelly
+++ b/src/main/resources/org/jenkinsci/account/taglib/layout.jelly
@@ -103,7 +103,7 @@
                             <div class='dropdown-menu'>
                                 <a class='dropdown-item feature' href='https://accounts.jenkins.io/' title='Create/manage your account for accessing wiki, issue tracker, etc'>Account Management</a>
                                 <a class='dropdown-item' href='https://www.jenkins.io/chat' title='Chat with the rest of the Jenkins community on IRC'>Chat</a>
-                                <a class='dropdown-item feature' href='https://issues.jenkins-ci.org/'>Issue Tracker</a>
+                                <a class='dropdown-item feature' href='https://issues.jenkins.io/'>Issue Tracker</a>
                                 <a class='dropdown-item' href='https://www.jenkins.io/mailing-lists' title='Browse Jenkins mailing list archives and/or subscribe to lists'>Mailing Lists</a>
                                 <a class='dropdown-item feature' href='https://wiki.jenkins-ci.org/'>Wiki</a>
                             </div>
@@ -288,7 +288,7 @@ Ruby
 <h5>Project</h5>
 <ul class='project'>
 <li>
-<a href='https://issues.jenkins-ci.org'>
+<a href='https://issues.jenkins.io'>
 Issue tracker
 </a>
 </li>


### PR DESCRIPTION
The default jira url is now wiki.jenkins.io

Signed-off-by: Olivier Vernin <olivier@vernin.me>