### PR TITLE
Don't download the dd agent through the frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ COPY config.properties.example /etc/accountapp/config.properties.example
 COPY circuitBreaker.txt /etc/accountapp/circuitBreaker.txt
 COPY entrypoint.sh /entrypoint.sh
 
-ADD https://search.maven.org/remote_content?g=com.datadoghq&a=dd-java-agent&v=0.9.0 /home/jetty/dd-java-agent.jar
+ENV DD_AGENT_VERSION = 0.9.0
+ADD https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_AGENT_VERSION/dd-java-agent-"$DD_AGENT_VERSION".jar /home/jetty/dd-java-agent.jar
 
 COPY --chown=jetty:root --from=build /app/build/libs/accountapp*.war /var/lib/jetty/webapps/ROOT.war
 


### PR DESCRIPTION
Minor QoL change to download the datadog agent from a sane URL.

Bonus points: This is something renovate picks up and and maintains itself.