### PR TITLE
Use a mail implementation not api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,8 +42,9 @@ dependencies {
 
     implementation("commons-jelly:commons-jelly-tags-define:1.0")
 
-    implementation("javax.mail:javax.mail-api:1.6.2")
-    implementation("javax.activation:activation:1.1.1")
+    implementation("com.sun.mail:jakarta.mail:1.6.7")
+
+    implementation("jakarta.activation:jakarta.activation-api:1.2.2")
 
     implementation("io.jenkins.backend:jira-rest-ldap-syncer:1.2") {
         exclude(module ="javamail")


### PR DESCRIPTION
Caused by https://github.com/jenkins-infra/account-app/pull/143

see https://github.com/jenkins-infra/helpdesk/issues/3195

I'm not 100% sure what's going on here.

Locally I got `java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger`

In production it's getting `com.sun.mail.smtp.SMTPSendFailedException: 550 Unauthenticated senders not allowed`

I was able to reset the users password from my local machine port forwarding to prod ldap with this change