### PR TITLE
chore(Dockerfile) correct the DD_AGENT download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY config.properties.example /etc/accountapp/config.properties.example
 COPY circuitBreaker.txt /etc/accountapp/circuitBreaker.txt
 COPY entrypoint.sh /entrypoint.sh
 
-ENV DD_AGENT_VERSION = 0.9.0
+ENV DD_AGENT_VERSION=0.9.0
 ADD https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_AGENT_VERSION/dd-java-agent-"$DD_AGENT_VERSION".jar /home/jetty/dd-java-agent.jar
 
 COPY --chown=jetty:root --from=build /app/build/libs/accountapp*.war /var/lib/jetty/webapps/ROOT.war


### PR DESCRIPTION
Caused by https://github.com/jenkins-infra/account-app/pull/160 (spaces around the env var at first sight)

Fixes the following build error:

```console
Step 19/31 : ADD [https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_AGENT_VERSION/dd-java-agent-"$DD_AGENT_VERSION".jar](https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_AGENT_VERSION/dd-java-agent-%22$DD_AGENT_VERSION%22.jar) /home/jetty/dd-java-agent.jar
ADD failed: failed to GET https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/= 0.9.0/dd-java-agent-= 0.9.0.jar with status 404 Not Found: <html>
```

Gotta check why the check did not fail in the PR #160 