### PR TITLE
Replace ci.jenkins.io with Artifactory URL

### DIFF
--- a/src/main/resources/org/jenkinsci/account/Application/index.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/index.jelly
@@ -5,7 +5,7 @@
     <p>
     You can create/manage your user account that you use for accessing
     <a href="https://issues.jenkins.io/" target="_blank">Jira</a>,
-    <a href="https://ci.jenkins.io/" target="_blank">ci.jenkins.io</a>,
+    <a href="https://repo.jenkins-ci.org/" target="_blank">Artifactory</a>,
     VPN and other services within the <a href="https://www.jenkins.io/projects/infrastructure" target="_top">Jenkins Infrastructure</a>.
     </p>
 


### PR DESCRIPTION
While the current wording is not wrong in any kind, it's not much of use for the ordinary Jenkins plugin or library developer. You can't do anything with your LDAP account on ci.j, unless you have specific permission.
Job configuration happens exclusively through your Jenkinsfile, not through the web UI.
