### PR TITLE
Upgrade to Jetty 10, Java 17, Jakarta dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM eclipse-temurin:8 AS build
+FROM eclipse-temurin:17 AS build
 
 WORKDIR /app
 COPY . .
 RUN ./gradlew --no-daemon --info war -x test -x integrationTest
 
-FROM jetty:jre8 AS production
+FROM jetty:10.0.12-jre17 AS production
 
 LABEL \
   description="Deploy Jenkins infra account app" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'jdk11'
+        label 'jdk17'
     }
 
     stages {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,8 @@ plugins {
     `jvm-test-suite`
     `maven-publish`
     war
-    id("org.gretty") version "3.0.9"
+    id("org.gretty") version "3.1.0"
+    id("com.github.ben-manes.versions") version "0.43.0"
 }
 
 group = "org.jenkins-ci"
@@ -17,12 +18,12 @@ repositories {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 plugins.withId("java") {
     the<JavaPluginExtension>().toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 
@@ -49,7 +50,7 @@ testing {
 
                 implementation("io.github.bonigarcia:webdrivermanager:5.3.1")
 
-                implementation("com.sun.mail:jakarta.mail:1.6.7")
+                implementation("com.sun.mail:jakarta.mail:2.0.1")
 
                 implementation("org.seleniumhq.selenium:selenium-java:4.6.0")
                 implementation("org.seleniumhq.selenium:selenium-chrome-driver:4.6.0")
@@ -57,7 +58,7 @@ testing {
 
                 implementation("com.unboundid:unboundid-ldapsdk:6.0.6")
 
-                implementation("com.icegreen:greenmail-junit5:1.6.11")
+                implementation("com.icegreen:greenmail-junit5:2.0.0-alpha-2")
             }
 
             targets {
@@ -85,18 +86,17 @@ dependencies {
     implementation("org.glassfish:javax.json:1.1.4")
     implementation("commons-codec:commons-codec:1.15")
 
-    implementation("org.kohsuke.stapler:stapler:1.263")
-    implementation("org.kohsuke.stapler:stapler-jelly:1.263")
-    implementation("org.kohsuke.stapler:stapler-openid-server:[1.0,2.0)")
+    implementation("org.kohsuke.stapler:stapler-jelly:1747.v9580b_2f1d80b")
+    implementation("org.kohsuke.stapler:stapler-openid-server:1.0")
 
     implementation("commons-jelly:commons-jelly-tags-define:1.0")
 
-    implementation("com.sun.mail:jakarta.mail:1.6.7")
+    implementation("com.sun.mail:jakarta.mail:2.0.1")
 
-    implementation("jakarta.activation:jakarta.activation-api:1.2.2")
+    implementation("com.sun.activation:jakarta.activation:2.0.1")
 
     implementation("io.jenkins.backend:jira-rest-ldap-syncer:1.2") {
-        exclude(module ="javamail")
+        exclude(module ="javax.mail-api")
     }
 
     implementation("org.webjars:webjars-servlet-2.x:1.6")
@@ -105,6 +105,10 @@ dependencies {
     implementation("org.webjars.bower:fontawesome:4.7.0")
 
     implementation("com.captcha:botdetect-jsp20:4.0.beta3")
+
+    implementation("com.github.spotbugs:spotbugs-annotations:4.7.3")
+
+    implementation("com.google.guava:guava:31.1-jre")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
 }
@@ -128,4 +132,5 @@ gretty {
     httpPort = 8080
 
     integrationTestTask = "integrationTest"
+    servletContainer = "jetty10"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,14 @@
 rootProject.name = "accountapp"
+
+// https://github.com/dom4j/dom4j/pull/116#issuecomment-770092526
+dependencyResolutionManagement {
+    components {
+        withModule("org.dom4j:dom4j") {
+            allVariants {
+                withDependencies {
+                    clear()
+                }
+            }
+        }
+    }
+}

--- a/src/it/java/org/jenkinsci/account/ui/admin/ResetPasswordAdminTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/ResetPasswordAdminTest.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.account.ui.admin;
 
+import jakarta.mail.MessagingException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.regex.Matcher;
-import javax.mail.MessagingException;
 import org.jenkinsci.account.ui.BaseTest;
 import org.jenkinsci.account.ui.email.Emails;
 import org.jenkinsci.account.ui.login.LoginPage;

--- a/src/it/java/org/jenkinsci/account/ui/email/ReadInboundEmailService.java
+++ b/src/it/java/org/jenkinsci/account/ui/email/ReadInboundEmailService.java
@@ -1,17 +1,15 @@
 package org.jenkinsci.account.ui.email;
 
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.internet.InternetAddress;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Properties;
-import javax.mail.Folder;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Store;
-import javax.mail.internet.InternetAddress;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.sun.mail.imap.IMAPFolder;
 
 public class ReadInboundEmailService {

--- a/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordTest.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.account.ui.resetpassword;
 
+import jakarta.mail.MessagingException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.regex.Matcher;
-import javax.mail.MessagingException;
 import org.jenkinsci.account.ui.BaseTest;
 import org.jenkinsci.account.ui.email.Emails;
 import org.jenkinsci.account.ui.login.LoginPage;

--- a/src/main/java/org/jenkinsci/account/AdminUI.java
+++ b/src/main/java/org/jenkinsci/account/AdminUI.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.account;
 
+import jakarta.mail.MessagingException;
 import org.jenkinsci.account.Application.User;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -7,7 +8,6 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.mail.MessagingException;
 import javax.naming.NamingException;
 import javax.naming.ldap.LdapContext;
 import javax.servlet.http.HttpServletResponse;


### PR DESCRIPTION
- I've ran all the recent regression tests that I've added
- I've manually checked sign-up as that's not tested yet
- I've built the docker image and sanity checked the app using the `docker compose` file (logged in)

first I tried jetty 11 but we can't upgrade to that till:
- stapler is updated to support jakarta
- the captcha library is dropped / upgraded / replaced