### PR TITLE
Fix email field signup spacing

### DIFF
--- a/src/main/resources/org/jenkinsci/account/Application/signup.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/signup.jelly
@@ -34,6 +34,9 @@
       <div class="form-group">
         <label for="email">Email address</label>
         <input type="email" name="email" id="email" class="form-control text"/>
+      </div>
+
+      <div class="form-group">
         <label for="emailconfirm">Confirm your Email address</label>
         <input type="email" name="emailconfirm" id="emailconfirm" class="form-control text"/>
       </div>


### PR DESCRIPTION
A small fix up, to align the email and confirmation field layout.

**Before**:
![Screenshot 2022-11-14 at 12 42 23](https://user-images.githubusercontent.com/13383509/201651937-a405d96e-58af-4311-a624-f98fd6458cf3.png)

**After**:
![Screenshot 2022-11-14 at 12 42 43](https://user-images.githubusercontent.com/13383509/201651929-db670120-14cc-4109-9228-b906b3ce3738.png)