### PR TITLE
Remove Jira sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ LABEL \
 ENV DD_AGENT_SERVICE_PORT="8126"
 ENV CIRCUIT_BREAKER_FILE=/etc/accountapp/circuitBreaker.txt
 ENV SMTP_SERVER=localhost
-ENV JIRA_URL=https://issues.jenkins.io
 ENV APP_URL=http://accounts.jenkins.io/
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ For deploying to production, this app is packaged as a container.
 To run the container locally:
 
 ```shell
-export JIRA_USERNAME=<your-jira-username>
-export JIRA_PASSWORD=<your-jira-password>
 docker compose up --build app
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,10 +95,6 @@ dependencies {
 
     implementation("com.sun.activation:jakarta.activation:2.0.1")
 
-    implementation("io.jenkins.backend:jira-rest-ldap-syncer:1.2") {
-        exclude(module ="javax.mail-api")
-    }
-
     implementation("org.webjars:webjars-servlet-2.x:1.6")
     implementation("org.webjars:jquery:3.6.1")
     implementation("org.webjars:jquery-ui:1.13.2")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,9 +16,6 @@ services:
     build: .
     image: accountapp:latest
     environment:
-      - JIRA_USERNAME
-      - JIRA_PASSWORD
-      - JIRA_URL=https://issues.jenkins.io
       - LDAP_URL=ldap://ldap:389
     depends_on:
       - ldap

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,14 +2,7 @@
 
 set -e
 
-: "${JIRA_USERNAME:?Jira user required}"
-: "${JIRA_PASSWORD:?Jira password required}"
-: "${JIRA_URL:? Jira url required}"
-
 exec java \
-    -Djira.username="$JIRA_USERNAME" \
-    -Djira.password="$JIRA_PASSWORD" \
-    -Djira.url="$JIRA_URL" \
     -Dcom.sun.jndi.ldap.connect.pool=true \
     -Dcom.sun.jndi.ldap.connect.pool.protocol="plain ssl" \
     -Dcom.sun.jndi.ldap.connect.pool.maxsize=0 \

--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -2,8 +2,6 @@ package org.jenkinsci.account;
 
 import com.captcha.botdetect.web.servlet.Captcha;
 import com.google.common.net.InetAddresses;
-import io.jenkins.backend.jiraldapsyncer.JiraLdapSyncer;
-import io.jenkins.backend.jiraldapsyncer.ServiceLocator;
 import jakarta.mail.Authenticator;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -14,7 +12,6 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.rmi.RemoteException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -322,13 +319,6 @@ public class Application {
             throw new UserError("ID "+userid+" is already taken. Perhaps you already have an account imported from legacy java.net? You may try resetting the password.");
         } finally {
             con.close();
-        }
-
-        try {
-            JiraLdapSyncer jiraLdapSyncer = (JiraLdapSyncer) new ServiceLocator().lookupService(JiraLdapSyncer.ROLE);
-            jiraLdapSyncer.syncOneUserFromLDAPToJIRA(userid);
-        } catch (RemoteException e) {
-            LOGGER.log(Level.SEVERE, "Failed to register " + userid + " to JIRA", e);
         }
 
         LOGGER.info("User "+userid+" signed up: "+email);


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/account-app/issues/185

We don't need this because we auto-create users on initial Jira login, this functionality was added before Jira had that feature.
All maintainers need to login to Jira before they can host a plugin / be mentioned in RPU.