### PR TITLE
Add repo to footer and enable GH issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,33 @@
+name: '🐛 Bug report'
+labels: 'bug'
+description: 'Create a bug report for the website'
+
+body:
+  - type: input
+    id: problem
+    attributes:
+      label: Problem with this page
+      description: The page URL you encounter issues on.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: possible-solution
+    attributes:
+      label: Possible solution
+      description: If you have suggestions on a fix for the bug, please describe it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,0 +1,21 @@
+name: '🚀 Website enhancement'
+labels: 'enhancement'
+description: 'I have a suggestion how to improve the website (and may want to implement it 🙂)!'
+
+body:
+  - type: textarea
+    attributes:
+      id: suggestion
+      label: Suggestion
+      description: A clear and concise description of what the problem is. Ex. `I have an issue when [...]`, `As a Jenkins user, I want to [...]
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      id: links
+      label: Links
+      description: Link any related documentation pages and other materials.
+      placeholder: |
+        * Links 1
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,0 +1,17 @@
+name: '📝 Documentation'
+labels: 'documentation'
+description: 'Let us know if any documentation is missing or could be improved'
+
+body:
+  - type: textarea
+    attributes:
+      id: suggestion
+      label: Describe your use-case which is not covered by existing documentation.
+      description: If it is easier to submit a documentation patch instead of writing an issue, just do it!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/src/main/resources/org/jenkinsci/account/taglib/layout.jelly
+++ b/src/main/resources/org/jenkinsci/account/taglib/layout.jelly
@@ -87,7 +87,8 @@
 
     <script src='https://www.jenkins.io/assets/bower/anchor-js/anchor.min.js'></script>
 <script src='https://www.jenkins.io/assets/bower/bootstrap/js/bootstrap.min.js'></script>
-<jio-footer id='footer' style="position:absolute; width:100%" property="https://accounts.jenkins.io"></jio-footer>
+<jio-footer id='footer' style="position:absolute; width:100%" property="https://accounts.jenkins.io"
+            reportAProblemTemplate="1-bug.yml" githubRepo="jenkins-infra/account-app" githubBranch="main"></jio-footer>
 <script>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
This PR utilizes a recent jio addition allowing you to specify template the footer should link to, in case you want to report an issue with a page.