### PR TITLE
feat: allow configuring the sender email address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ LABEL \
 ENV DD_AGENT_SERVICE_PORT="8126"
 ENV CIRCUIT_BREAKER_FILE=/etc/accountapp/circuitBreaker.txt
 ENV SMTP_SERVER=localhost
+ENV SMTP_SENDER=admin@jenkins-ci.org
 ENV APP_URL=http://accounts.jenkins.io/
 
 EXPOSE 8080

--- a/src/main/java/org/jenkinsci/account/Parameters.java
+++ b/src/main/java/org/jenkinsci/account/Parameters.java
@@ -44,6 +44,7 @@ public class Parameters {
 
     /**
      * smtpServer: The SMTP server to connect to.
+     * smtpSender: The sender email address used to send emails
      * smtpUser: Default user name for SMTP.
      * smtpAuth: If true, attempt to authenticate the user using the AUTH command.
      * smtpPassword: SMTP password for SMTP server.
@@ -53,6 +54,9 @@ public class Parameters {
     }
     public String smtpServer() {
         return mailConfig.getSmtpServer();
+    }
+    public String smtpSender() {
+        return mailConfig.getSmtpSender();
     }
     public String smtpUser() {
         return mailConfig.getSmtpUser();

--- a/src/main/java/org/jenkinsci/account/WebAppMain.java
+++ b/src/main/java/org/jenkinsci/account/WebAppMain.java
@@ -36,6 +36,7 @@ public class WebAppMain extends AbstractWebAppMain<Application> {
 
         MailConfig mailConfig = new MailConfig(
                 conf.getString("mail.server"),
+                conf.getString("mail.sender"),
                 conf.getInt("mail.port"),
                 conf.hasPath("mail.user") ? conf.getString("mail.user") : null,
                 conf.hasPath("mail.password") ? conf.getString("mail.password") : null,

--- a/src/main/java/org/jenkinsci/account/config/MailConfig.java
+++ b/src/main/java/org/jenkinsci/account/config/MailConfig.java
@@ -3,13 +3,15 @@ package org.jenkinsci.account.config;
 public class MailConfig {
 
     private final String smtpServer;
+    private final String smtpSender;
     private final String smtpUser;
     private final String smtpPassword;
     private final boolean smtpAuth;
     private final int smtpPort;
 
-    public MailConfig(String smtpServer, int smtpPort, String smtpUser, String smtpPassword, boolean smtpAuth) {
+    public MailConfig(String smtpServer, String smtpSender, int smtpPort, String smtpUser, String smtpPassword, boolean smtpAuth) {
         this.smtpServer = smtpServer;
+        this.smtpSender = smtpSender;
         this.smtpUser = smtpUser;
         this.smtpPassword = smtpPassword;
         this.smtpAuth = smtpAuth;
@@ -18,6 +20,10 @@ public class MailConfig {
 
     public String getSmtpServer() {
         return smtpServer;
+    }
+
+    public String getSmtpSender() {
+        return smtpSender;
     }
 
     public String getSmtpUser() {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,7 +20,7 @@ ldap {
 mail {
     server = localhost
     server = ${?SMTP_SERVER}
-    sender = admin@jenkins-ci.org
+    sender = "admin@jenkins-ci.org"
     sender = ${?SMTP_SENDER}
     port   = 2525
     port   = ${?SMTP_PORT}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,6 +20,8 @@ ldap {
 mail {
     server = localhost
     server = ${?SMTP_SERVER}
+    sender = admin@jenkins-ci.org
+    sender = ${?SMTP_SENDER}
     port   = 2525
     port   = ${?SMTP_PORT}
     user = ${?SMTP_USER}


### PR DESCRIPTION
Allow to configure the sender email address instead of using the hardcoded `admin@jenkins-ci.org` email address.

Also replace the `Admin` default sender name by `Jenkins Accounts`.