### PR TITLE
chore: do not override the provided SMTP port with an hardcoded value when setting an auth

### DIFF
--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -444,7 +444,6 @@ public class Application {
         if(params.smtpAuth()) {
             props.put("mail.smtp.auth", params.smtpAuth());
             props.put("mail.smtp.starttls.enable", true);
-            props.put("mail.smtp.port", 587);
             session = Session.getInstance(props,
                     new Authenticator() {
                         protected PasswordAuthentication getPasswordAuthentication() {


### PR DESCRIPTION
Currently the provided SMTP port parameter isn't respected when the `useAuth` setting is set to `true`.

This PR removes its replacement to `587` in such case.