### PR TITLE
chore: add arm64 image to ci.jenkins.io build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         }
         stage('Docker image') {
             steps {
-                buildDockerAndPublishImage('account-app', [rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
+                parallelDockerUpdatecli([imageName: 'account-app', rebuildImageOnPeriodicJob: false, buildDockerConfig : [targetplatforms: 'linux/amd64,linux/arm64']])
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         }
         stage('Docker image') {
             steps {
-                buildDockerAndPublishImage('account-app', [rebuildImageOnPeriodicJob: false])
+                buildDockerAndPublishImage('account-app', [rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
             }
         }
     }


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3619#issuecomment-1713522131

EDIT: the arm64 is already built on infra.ci.jenkins.io since https://github.com/jenkins-infra/account-app/pull/299, this PR also builds it on ci.jenkins.io