### PR TITLE
Run docker image on infra.ci only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,10 @@ pipeline {
             }
         }
         stage('Docker image') {
-            steps {
-                parallelDockerUpdatecli([imageName: 'account-app', rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
-            }
+            expression { infra.isInfra() }
+                steps {
+                    parallelDockerUpdatecli([imageName: 'account-app', rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
+                }
         }
     }
 }


### PR DESCRIPTION
We don't store creds on ci.j, causing the step to fail every time on ci.jenkins.io. I propose we run this on infra.ci only, from where the image is deployed.