### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Renovate is already doing this better.

Dependabot didn't update the comment for the version while renovate did

https://github.com/jenkins-infra/account-app/pull/346
https://github.com/jenkins-infra/account-app/pull/345