### PR TITLE
chore: disable publication from ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,13 +30,11 @@ pipeline {
         }
         stage('Docker image') {
             steps {
-                parallelDockerUpdatecli([
-                    imageName: 'account-app',
+                buildDockerAndPublishImage('account-app', [
                     rebuildImageOnPeriodicJob: false,
-                    buildDockerConfig: [
-                        targetplatforms: 'linux/amd64,linux/arm64',
-                        disablePublication: true
-                    ]
+                    automaticSemanticVersioning: true,
+                    targetplatforms: 'linux/amd64,linux/arm64',
+                    disablePublication: true
                 ])
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/784/head') _
+
 pipeline {
     agent {
         label 'jdk17'
@@ -28,7 +30,14 @@ pipeline {
         }
         stage('Docker image') {
             steps {
-                parallelDockerUpdatecli([imageName: 'account-app', rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
+                parallelDockerUpdatecli([
+                    imageName: 'account-app',
+                    rebuildImageOnPeriodicJob: false,
+                    buildDockerConfig: [
+                        targetplatforms: 'linux/amd64,linux/arm64',
+                        disablePublication: true
+                    ]
+                ])
             }
         }
     }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,5 @@
-parallelDockerUpdatecli([imageName: 'account-app', rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
+buildDockerAndPublishImage('account-app', [
+    rebuildImageOnPeriodicJob: false,
+    automaticSemanticVersioning: true,
+    targetplatforms: 'linux/amd64,linux/arm64'
+])


### PR DESCRIPTION
This PR disables tagging and publication of docker image and github release from ci.jenkins.io

The merge of this PR will also serve as a test for https://github.com/jenkins-infra/pipeline-library/pull/784

Ref:
- https://github.com/jenkins-infra/account-app/pull/339#issuecomment-1872404386