### PR TITLE
fix: remove unused `updatecli` from pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,11 @@ pipeline {
         }
         stage('Docker image') {
             steps {
-                parallelDockerUpdatecli([imageName: 'account-app', rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
+                buildDockerAndPublishImage('account-app', [
+                    rebuildImageOnPeriodicJob: false,
+                    automaticSemanticVersioning: true,
+                    targetplatforms: 'linux/amd64,linux/arm64'
+                ])
             }
         }
     }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,5 @@
-parallelDockerUpdatecli([imageName: 'account-app', rebuildImageOnPeriodicJob: false, buildDockerConfig: [targetplatforms: 'linux/amd64,linux/arm64']])
+buildDockerAndPublishImage('account-app', [
+    rebuildImageOnPeriodicJob: false,
+    automaticSemanticVersioning: true,
+    targetplatforms: 'linux/amd64,linux/arm64'
+])


### PR DESCRIPTION
This PR replaces `parallelDockerUpdatecli` by `buildDockerAndPublishImage` (with `automaticSemanticVersioning` set to true like in `parallelDockerUpdatecli`) to remove updatecli from pipelines in order to avoid timeout as there isn't any updatecli manifest in this repository.

Note for reviewers: I've cherry-picked this change in #351 also needed to get successful builds on ci.jenkins.io. This other PR should be privileged.

Ref:
- #352 