### PR TITLE
Fix INFRA-2178 | Enforce 100-character limit for first and last name

### DIFF
--- a/src/main/java/org/jenkinsci/account/Myself.java
+++ b/src/main/java/org/jenkinsci/account/Myself.java
@@ -97,12 +97,12 @@ public class Myself {
             @QueryParameter String newPassword2
     ) throws Exception {
 
-        if (!isValidName(firstName))
+        if (!isValidName(firstName)) {
             throw new UserError("First name is too long");
-        
-        if (!isValidName(lastName))
+        }
+        if (!isValidName(lastName)) {
             throw new UserError("Last name is too long");
-
+        }
         final Attributes attrs = new BasicAttributes();
 
         attrs.put("givenName", fixEmpty(firstName));
@@ -177,9 +177,8 @@ public class Myself {
         return s;
     }
 
-    private boolean isValidName(String name){
-        if(name.length() > 100) return false;
-        return true;
+    private boolean isValidName(String name) {
+        return name.length() < 100;
     }
 
     private static final Logger LOGGER = Logger.getLogger(Myself.class.getName());

--- a/src/main/java/org/jenkinsci/account/Myself.java
+++ b/src/main/java/org/jenkinsci/account/Myself.java
@@ -98,15 +98,15 @@ public class Myself {
     ) throws Exception {
 
         if (!isValidName(firstName)) {
-            throw new UserError("First name is too long");
+            throw new UserError("First name is Invalid");
         }
         if (!isValidName(lastName)) {
-            throw new UserError("Last name is too long");
+            throw new UserError("Last name is Invalid");
         }
         final Attributes attrs = new BasicAttributes();
 
-        attrs.put("givenName", fixEmpty(firstName));
-        attrs.put("sn", fixEmpty(lastName));
+        attrs.put("givenName", firstName);
+        attrs.put("sn", lastName);
         attrs.put("mail", email);
         attrs.put(GITHUB_ID,fixEmpty(githubId));
         attrs.put(SSH_KEYS,fixEmpty(sshKeys)); // hack since I find it too hard to add custom attributes to LDAP
@@ -178,7 +178,7 @@ public class Myself {
     }
 
     private boolean isValidName(String name) {
-        return name.length() < 100;
+        return name != null && !name.isEmpty() && name.length() < 100;
     }
 
     private static final Logger LOGGER = Logger.getLogger(Myself.class.getName());

--- a/src/main/java/org/jenkinsci/account/Myself.java
+++ b/src/main/java/org/jenkinsci/account/Myself.java
@@ -97,6 +97,12 @@ public class Myself {
             @QueryParameter String newPassword2
     ) throws Exception {
 
+        if (!isValidName(firstName))
+            throw new UserError("First name is too long");
+        
+        if (!isValidName(lastName))
+            throw new UserError("Last name is too long");
+
         final Attributes attrs = new BasicAttributes();
 
         attrs.put("givenName", fixEmpty(firstName));
@@ -169,6 +175,11 @@ public class Myself {
     private String fixEmpty(String s) {
         if (s!=null && s.length()==0)   return null;
         return s;
+    }
+
+    private boolean isValidName(String name){
+        if(name.length() > 100) return false;
+        return true;
     }
 
     private static final Logger LOGGER = Logger.getLogger(Myself.class.getName());


### PR DESCRIPTION
## Enforce 100-character limit for first and last name

Previously, there was no size limit for the last name field, which could lead to unexpected behaviour. This commit sets a maximum length of 100 characters for both first and last names.

Fixes jenkins-infra/helpdesk#1813

### Before
![Success Message](https://github.com/user-attachments/assets/fc94c686-d6fb-449d-a3cf-210372879a7c)


### After
![Error Message](https://github.com/user-attachments/assets/cb15addb-8615-46fd-a23f-e66d83a0215b)

