### PR TITLE
Added Mock LDAP

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   ldap:
-    image: jenkinsciinfra/mock-ldap:latest
+    build: ./mock-ldap
     ports:
         - "1636:636"
         - "1389:389"
@@ -14,7 +14,6 @@ services:
 
   app:
     build: .
-    image: accountapp:latest
     environment:
       - LDAP_URL=ldap://ldap:389
     depends_on:

--- a/mock-ldap/Dockerfile
+++ b/mock-ldap/Dockerfile
@@ -1,0 +1,12 @@
+FROM nickstenning/slapd
+
+ENV LDAP_ROOTPASS s3cr3t
+ENV LDAP_DOMAIN jenkins-ci.org
+ENV LDAP_ORGANISATION MockJenkins
+
+RUN apt-get -y update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y ldap-utils
+
+ADD data.ldif /tmp/data.ldif
+RUN /etc/service/slapd/run & sleep 3; \
+    ldapadd -H ldap:/// -x -D cn=admin,dc=jenkins-ci,dc=org -w s3cr3t < /tmp/data.ldif

--- a/mock-ldap/data.ldif
+++ b/mock-ldap/data.ldif
@@ -1,0 +1,60 @@
+#
+# Dummy user database for testing
+#
+# User 'kohsuke' is admin, user 'alice' is a regular user.
+# Both has the password 'password'
+#
+
+#dn: dc=jenkins-ci,dc=org
+#objectClass: top
+#objectClass: dcObject
+#objectClass: organization
+#o: Jenkins users
+#dc: Jenkins-Ci
+#description: Jenkins users
+
+#dn: cn=admin,dc=jenkins-ci,dc=org
+#objectClass: simpleSecurityObject
+#objectClass: organizationalRole
+#cn: admin
+#description: LDAP administrator
+#userPassword: {SSHA}yI6cZwQadOA1e+/f+T+H3eCQQhRzYWx0
+
+dn: ou=people,dc=jenkins-ci,dc=org
+objectClass: organizationalUnit
+ou: people
+
+dn: ou=groups,dc=jenkins-ci,dc=org
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=admins,ou=groups,dc=jenkins-ci,dc=org
+objectClass: groupOfNames
+cn: admins
+description: people with infrastructure admin access
+member: cn=kohsuke,ou=people,dc=jenkins-ci,dc=org
+
+dn: cn=all,ou=groups,dc=jenkins-ci,dc=org
+objectClass: groupOfNames
+cn: all
+member: cn=kohsuke,ou=people,dc=jenkins-ci,dc=org
+member: cn=kohsuke2,ou=people,dc=jenkins-ci,dc=org
+
+dn: cn=kohsuke,ou=people,dc=jenkins-ci,dc=org
+objectClass: inetOrgPerson
+cn: kohsuke
+mail: kk@kohsuke.org
+givenName: Kohsuke
+employeeNumber: kohsuke
+preferredLanguage: yyy
+sn: Kawaguchi
+userPassword: {SSHA}yI6cZwQadOA1e+/f+T+H3eCQQhRzYWx0
+
+dn: cn=alice,ou=people,dc=jenkins-ci,dc=org
+objectClass: inetOrgPerson
+cn: alice
+mail: bob@jenkins-ci.org
+givenName: Alice
+employeeNumber: alice
+sn: Ashley
+userPassword: {SSHA}yI6cZwQadOA1e+/f+T+H3eCQQhRzYWx0


### PR DESCRIPTION
## Addition of Mock LDAP

The mock LDAP for Jenkins, which is present at https://github.com/jenkins-infra/mock-ldap, has been added so that the image is freshly built each time. I also updated the docker-compose.yaml to point it to the newly added Dockerfile. I also removed the image attribute from accountapp service in docker-compose since it doesn't exist on the Docker hub anymore.  

This has been done as per the discussion here https://github.com/jenkins-infra/mock-ldap/issues/5