### PR TITLE
Use release drafter 7.1.1

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,8 @@
 name: release-drafter
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
   release:
 # Only allow 1 release-drafter build at a time to avoid creating multiple "next" releases

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Release Drafter
-        uses: release-drafter/release-drafter@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           name: next
           tag: next

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,5 +19,4 @@ jobs:
           name: next
           tag: next
           version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Use release drafter 7.1.1

Updates to make release drafter work as expected with latest release.

- Use release drafter 7.1.1
- Run release drafter on main branch
