### PR TITLE
Fix CSRF vulnerabilities

### DIFF
--- a/src/main/java/org/jenkinsci/account/AdminUI.java
+++ b/src/main/java/org/jenkinsci/account/AdminUI.java
@@ -37,6 +37,7 @@ public class AdminUI {
         return app.circuitBreaker;
     }
 
+    @RequirePOST
     public HttpResponse doSearch(@QueryParameter String word) throws NamingException {
         List<User> all = new ArrayList<User>();
         LdapContext con = app.connect();

--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -45,6 +45,7 @@ import javax.naming.ldap.LdapContext;
 import javax.servlet.http.Cookie;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.account.openid.JenkinsOpenIDServer;
+import org.jenkinsci.account.security.CrumbIssuer;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -53,6 +54,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import static javax.naming.directory.DirContext.ADD_ATTRIBUTE;
 import static javax.naming.directory.DirContext.REMOVE_ATTRIBUTE;
@@ -100,6 +102,7 @@ public class Application {
     /**
      * Receives the sign-up form submission.
      */
+    @RequirePOST
     public HttpResponse doDoSignup(
             StaplerRequest request,
             StaplerResponse response,
@@ -329,6 +332,7 @@ public class Application {
     /**
      * Handles the password reset form submission.
      */
+    @RequirePOST
     public HttpResponse doDoPasswordReset(@QueryParameter String id, @QueryParameter String reason) throws Exception {
         final DirContext con = connect();
         if (id.isEmpty())
@@ -496,6 +500,7 @@ public class Application {
     /**
      * Handles the login form submission.
      */
+    @RequirePOST
     public HttpResponse doDoLogin(
             @QueryParameter String userid,
             @QueryParameter String password,
@@ -521,7 +526,9 @@ public class Application {
             LdapContext context = connect(dn, password);    // make sure the password is valid
             try {
                 Myself myself = new Myself(this, dn, context.getAttributes(dn), getGroups(dn,context));
-                Stapler.getCurrentRequest().getSession().setAttribute(Myself.class.getName(), myself);
+                StaplerRequest req = Stapler.getCurrentRequest();
+                req.getSession().invalidate();
+                req.getSession(true).setAttribute(Myself.class.getName(), myself);
                 return myself;
             } finally {
                 context.close();
@@ -553,6 +560,10 @@ public class Application {
     public HttpResponse doLogout(StaplerRequest req) {
         req.getSession().invalidate();
         return HttpResponses.redirectToDot();
+    }
+
+    public String getCrumb() {
+        return CrumbIssuer.getCrumb(Stapler.getCurrentRequest());
     }
 
     public boolean isLoggedIn() {

--- a/src/main/java/org/jenkinsci/account/Myself.java
+++ b/src/main/java/org/jenkinsci/account/Myself.java
@@ -13,6 +13,7 @@ import javax.naming.directory.DirContext;
 import javax.naming.ldap.LdapContext;
 import java.util.Set;
 import java.util.logging.Logger;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import static org.jenkinsci.account.LdapAbuse.GITHUB_ID;
 import static org.jenkinsci.account.LdapAbuse.SSH_KEYS;
@@ -86,6 +87,7 @@ public class Myself {
         return att!=null ? (String) att.get() : null;
     }
 
+    @RequirePOST
     public HttpResponse doUpdate(
             @QueryParameter String firstName,
             @QueryParameter String lastName,
@@ -133,8 +135,7 @@ public class Myself {
         return new HttpRedirect("done");
     }
 
-    // no longer invoked directly from outside, but left as is
-    public HttpResponse doChangePassword(
+    protected HttpResponse doChangePassword(
             @QueryParameter String password,
             @QueryParameter String newPassword1,
             @QueryParameter String newPassword2

--- a/src/main/java/org/jenkinsci/account/WebAppMain.java
+++ b/src/main/java/org/jenkinsci/account/WebAppMain.java
@@ -2,8 +2,11 @@ package org.jenkinsci.account;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import javax.servlet.ServletContextEvent;
 import org.jenkinsci.account.config.LdapConfig;
 import org.jenkinsci.account.config.MailConfig;
+import org.jenkinsci.account.security.CrumbIssuer;
+import org.kohsuke.stapler.WebApp;
 import org.kohsuke.stapler.framework.AbstractWebAppMain;
 import org.kohsuke.stapler.jelly.DefaultScriptInvoker;
 
@@ -21,6 +24,12 @@ public class WebAppMain extends AbstractWebAppMain<Application> {
     @Override
     protected String getApplicationName() {
         return "APP";
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        super.contextInitialized(event);
+        WebApp.get(event.getServletContext()).setCrumbIssuer(new CrumbIssuer());
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/account/security/CrumbIssuer.java
+++ b/src/main/java/org/jenkinsci/account/security/CrumbIssuer.java
@@ -1,0 +1,58 @@
+package org.jenkinsci.account.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HexFormat;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import org.kohsuke.stapler.StaplerRequest;
+
+public class CrumbIssuer extends org.kohsuke.stapler.CrumbIssuer {
+
+    public static final String CRUMB_FIELD = "crumb";
+
+    private static final byte[] KEY;
+
+    static {
+        KEY = new byte[32];
+        new SecureRandom().nextBytes(KEY);
+    }
+
+    @Override
+    public String issueCrumb(StaplerRequest request) {
+        return hmac(request.getSession().getId());
+    }
+
+    public static String getCrumb(HttpServletRequest request) {
+        return hmac(request.getSession().getId());
+    }
+
+    /** Validates a submitted crumb against the expected value for this session. */
+    public static void validate(HttpServletRequest request, String submitted) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            throw new SecurityException("Invalid or missing CSRF token. Please reload the page and try again.");
+        }
+        String expected = hmac(session.getId());
+        if (!MessageDigest.isEqual(
+                expected.getBytes(StandardCharsets.UTF_8),
+                submitted != null ? submitted.getBytes(StandardCharsets.UTF_8) : new byte[0])) {
+            throw new SecurityException("Invalid or missing CSRF token. Please reload the page and try again.");
+        }
+    }
+
+    private static String hmac(String sessionId) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(KEY, "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(sessionId.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new SecurityException("Failed to compute CSRF token", e);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/account/security/CsrfFilter.java
+++ b/src/main/java/org/jenkinsci/account/security/CsrfFilter.java
@@ -1,0 +1,54 @@
+package org.jenkinsci.account.security;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class CsrfFilter implements Filter {
+
+    private static final Logger LOGGER = Logger.getLogger(CsrfFilter.class.getName());
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!(request instanceof HttpServletRequest)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String servletPath = httpRequest.getServletPath();
+        if ("POST".equalsIgnoreCase(httpRequest.getMethod())
+                && !servletPath.startsWith("/botdetectcaptcha")) {
+            String submitted = httpRequest.getHeader(CrumbIssuer.CRUMB_FIELD);
+            if (submitted == null) {
+                submitted = httpRequest.getParameter(CrumbIssuer.CRUMB_FIELD);
+            }
+
+            try {
+                CrumbIssuer.validate(httpRequest, submitted);
+                chain.doFilter(request, response);
+            } catch (SecurityException e) {
+                LOGGER.warning("CSRF check failed for " + httpRequest.getRequestURI() + ": " + e.getMessage());
+                httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
+            }
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {}
+}

--- a/src/main/resources/org/jenkinsci/account/AdminUI/index.jelly
+++ b/src/main/resources/org/jenkinsci/account/AdminUI/index.jelly
@@ -6,6 +6,7 @@
           Type the username or email address to find the user.
         </p>
         <form method="post" action="search">
+          <input type="hidden" name="crumb" value="${app.crumb}"/>
           <div class="ac-form-group">
             <label for="word">Username or email address</label>
             <input type="text" name="word" class="form-control text"/>
@@ -28,6 +29,7 @@
           </p>
         </j:if>
         <form method="post" action="circuitBreaker/set">
+          <input type="hidden" name="crumb" value="${app.crumb}"/>
           <div class="ac-form-group">
             <label for="time">Circuit breaker is on until when? (YYYY/MM/DD HH:MM)</label>
             <input type="text" name="time" class="form-control text"/>

--- a/src/main/resources/org/jenkinsci/account/AdminUI/search.jelly
+++ b/src/main/resources/org/jenkinsci/account/AdminUI/search.jelly
@@ -26,12 +26,14 @@
           <td>${u.mail}</td>
           <td>
             <form method="post" action="passwordReset" style="margin:0">
+              <input type="hidden" name="crumb" value="${app.crumb}"/>
               <input type="hidden" name="id" value="${u.id}" />
               <input type="submit" value="Reset password" class="app-button" />
             </form>
           </td>
           <td>
             <form method="post" action="emailReset" style="margin:0">
+              <input type="hidden" name="crumb" value="${app.crumb}"/>
               <input type="hidden" name="id" value="${u.id}" />
               <input type="text" name="email" value="${u.mail}" class="form-control" />
               <input type="submit" value="Update" class="app-button" style="margin-left: 0.5rem" />
@@ -40,6 +42,7 @@
 
           <td>
             <form method="post" action="delete" style="margin:0">
+              <input type="hidden" name="crumb" value="${app.crumb}"/>
               <input type="hidden" name="id" value="${u.id}" />
               <input type="text" name="confirm" style="width:4em" class="form-control" />
               <input type="submit" value="Delete" class="app-button" style="margin-left: 0.5rem" />

--- a/src/main/resources/org/jenkinsci/account/AdminUI/signup.jelly
+++ b/src/main/resources/org/jenkinsci/account/AdminUI/signup.jelly
@@ -5,6 +5,7 @@
       Confirm creating the following user
     </p>
     <form method="post" action="doSignup">
+      <input type="hidden" name="crumb" value="${app.crumb}"/>
       <div class="ac-form-group">
         <label>User ID</label>
         <input type="text" name="userid" value="${request.getParameter('userId')}" class="form-control text" placeholder="Userid" />

--- a/src/main/resources/org/jenkinsci/account/Application/login.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/login.jelly
@@ -4,6 +4,7 @@
     <h1>Sign in</h1>
 
     <form method="post" action="doLogin">
+      <input type="hidden" name="crumb" value="${app.crumb}"/>
       <div class="ac-form-group">
         <label for="userid">Username</label>
         <input autofocus="autofocus" type="text" name="userid" class="form-control text" id="userid" />

--- a/src/main/resources/org/jenkinsci/account/Application/passwordReset.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/passwordReset.jelly
@@ -4,6 +4,7 @@
     <h1>Reset password</h1>
 
     <form method="post" action="doPasswordReset">
+      <input type="hidden" name="crumb" value="${app.crumb}"/>
       <div class="ac-form-group">
         <label>Username or email</label>
         <input type="text" name="id" class="form-control text"/>

--- a/src/main/resources/org/jenkinsci/account/Application/signup.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/signup.jelly
@@ -6,6 +6,7 @@
     <div class="ac-description">All fields are required</div>
 
     <form method="post" action="doSignup">
+      <input type="hidden" name="crumb" value="${app.crumb}"/>
       <div class="ac-form-group">
         <label for="userid">Username</label>
         <div class="ac-description">

--- a/src/main/resources/org/jenkinsci/account/Myself/index.jelly
+++ b/src/main/resources/org/jenkinsci/account/Myself/index.jelly
@@ -4,6 +4,7 @@
     <h1>Your profile</h1>
 
     <form method="post" action="update">
+    <input type="hidden" name="crumb" value="${app.crumb}"/>
     <div class="ac-form-group">
       <label>Username</label>
       <input type="text" readonly="true" value="${it.userId}" class="form-control text" disabled="true"/>

--- a/src/main/resources/org/jenkinsci/account/openid/JenkinsOpenIDSession/confirm.jelly
+++ b/src/main/resources/org/jenkinsci/account/openid/JenkinsOpenIDSession/confirm.jelly
@@ -6,6 +6,7 @@
     </div>
 
     <form method="post" action="verify">
+      <input type="hidden" name="crumb" value="${app.crumb}"/>
       <button type="submit">
         Proceed
       </button>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,15 @@
     <url-pattern>/botdetectcaptcha</url-pattern>
   </servlet-mapping>
 
+  <filter>
+    <filter-name>CsrfFilter</filter-name>
+    <filter-class>org.jenkinsci.account.security.CsrfFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CsrfFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
   <listener>
     <listener-class>org.jenkinsci.account.WebAppMain</listener-class>
   </listener>


### PR DESCRIPTION
The account app failed to have actual CSRF protection. Given we've wanted to migrate off of it towards Keycloak off and on for years, this never made the cut so far. Plus users are rarely logged in, reducing effectiveness of any attacks further. Still, all admins, security team members, or maintainers of popular, non-exclusive CD plugins are an interesting target for such attacks, so fix that here.

This is already deployed (thanks @lemeurherve!), so this PR is just cleaning up some afterwards.