### PR TITLE
Fix tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,9 @@ pipeline {
             }
         }
         stage('Test') {
+            environment {
+                SELENIUM_BROWSER_BINARY = sh(script: 'ls ${HOME}/.cache/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell', returnStdout: true).trim()
+            }
             steps {
                 sh './gradlew check'
             }

--- a/src/it/java/org/jenkinsci/account/ui/BaseTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/BaseTest.java
@@ -32,11 +32,14 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import java.time.Duration;
 
 @ExtendWith(BaseTest.ScreenShotOnFailedTestExtension.class)
 public class BaseTest {
 
     public ChromeDriver driver;
+    public WebDriverWait wait;
     protected InMemoryDirectoryServer ds;
 
     @RegisterExtension
@@ -86,12 +89,13 @@ public class BaseTest {
 
     public void startBrowser() {
         ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless", "--window-size=1920,1080");
+        options.addArguments("--headless", "--window-size=1920,1080", "--no-sandbox", "--disable-dev-shm-usage");
         String browserBinary = System.getenv("SELENIUM_BROWSER_BINARY");
         if (browserBinary != null && !browserBinary.isBlank()) {
             options.setBinary(browserBinary);
         }
         driver = new ChromeDriver(options);
+        wait = new WebDriverWait(driver, Duration.ofSeconds(10));
     }
 
     public void openHomePage() {

--- a/src/it/java/org/jenkinsci/account/ui/BaseTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/BaseTest.java
@@ -32,7 +32,6 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.WebDriverManager;
 
 @ExtendWith(BaseTest.ScreenShotOnFailedTestExtension.class)
 public class BaseTest {

--- a/src/it/java/org/jenkinsci/account/ui/BaseTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/BaseTest.java
@@ -52,7 +52,7 @@ public class BaseTest {
         wdm = WebDriverManager.chromedriver();
         String browserBinary = System.getenv("SELENIUM_BROWSER_BINARY");
         if (browserBinary != null && !browserBinary.isBlank()) {
-            wdm.browserPath(browserBinary);
+            wdm.browserBinary(browserBinary);
         }
         wdm.setup();
     }
@@ -90,7 +90,7 @@ public class BaseTest {
         options.addArguments("--headless", "--window-size=1920,1080");
         String browserBinary = System.getenv("SELENIUM_BROWSER_BINARY");
         if (browserBinary != null && !browserBinary.isBlank()) {
-            options.setBinaryLocation(browserBinary);
+            options.setBinary(browserBinary);
         }
         driver = new ChromeDriver(options);
     }

--- a/src/it/java/org/jenkinsci/account/ui/BaseTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/BaseTest.java
@@ -32,7 +32,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverManager;
 
 @ExtendWith(BaseTest.ScreenShotOnFailedTestExtension.class)
 public class BaseTest {

--- a/src/it/java/org/jenkinsci/account/ui/BaseTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/BaseTest.java
@@ -44,9 +44,16 @@ public class BaseTest {
 
     public static final ReadInboundEmailService READ_INBOUND_EMAIL_SERVICE = new ReadInboundEmailService("localhost", 3143);
 
+    private static WebDriverManager wdm;
+
     @BeforeAll
     static void setupAll() {
-        WebDriverManager.chromiumdriver().setup();
+        wdm = WebDriverManager.chromedriver();
+        String browserBinary = System.getenv("SELENIUM_BROWSER_BINARY");
+        if (browserBinary != null && !browserBinary.isBlank()) {
+            wdm.browserPath(browserBinary);
+        }
+        wdm.setup();
     }
 
     @BeforeEach
@@ -80,6 +87,10 @@ public class BaseTest {
     public void startBrowser() {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless", "--window-size=1920,1080");
+        String browserBinary = System.getenv("SELENIUM_BROWSER_BINARY");
+        if (browserBinary != null && !browserBinary.isBlank()) {
+            options.setBinaryLocation(browserBinary);
+        }
         driver = new ChromeDriver(options);
     }
 

--- a/src/it/java/org/jenkinsci/account/ui/BaseTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/BaseTest.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.WebDriver;
 
 @ExtendWith(BaseTest.ScreenShotOnFailedTestExtension.class)
 public class BaseTest {

--- a/src/it/java/org/jenkinsci/account/ui/admin/AdminPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/AdminPage.java
@@ -1,10 +1,12 @@
 package org.jenkinsci.account.ui.admin;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import java.util.List;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,19 +17,24 @@ public class AdminPage {
 
     @FindBy(xpath = "//button[contains(text(), 'Search')]")
     private WebElement searchButton;
-    private final WebDriver driver;
 
-    public AdminPage(WebDriver driver) {
+    private final WebDriver driver;
+    private final WebDriverWait wait;
+
+    public AdminPage(WebDriver driver, WebDriverWait wait) {
         this.driver = driver;
+        this.wait = wait;
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("word")));
         PageFactory.initElements(driver, this);
     }
 
     public void verifyOnPage() {
-        assertThat(driver.getTitle())
-                .contains("Admin");
+        wait.until(ExpectedConditions.titleContains("Admin"));
+        assertThat(driver.getTitle()).contains("Admin");
     }
 
     public void search(String query) {
+        wait.until(ExpectedConditions.elementToBeClickable(searchInput));
         searchInput.sendKeys(query);
         searchButton.click();
     }

--- a/src/it/java/org/jenkinsci/account/ui/admin/AdminResetPasswordResultPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/AdminResetPasswordResultPage.java
@@ -1,17 +1,23 @@
 package org.jenkinsci.account.ui.admin;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import java.util.List;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 // page_url = http://localhost:8080/admin/passwordReset
 public class AdminResetPasswordResultPage {
     @FindBy(xpath = "//p/code")
     private WebElement newPasswordText;
 
-    public AdminResetPasswordResultPage(WebDriver driver) {
+    private final WebDriverWait wait;
+
+    public AdminResetPasswordResultPage(WebDriver driver, WebDriverWait wait) {
+        this.wait = wait;
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//p/code")));
         PageFactory.initElements(driver, this);
     }
 

--- a/src/it/java/org/jenkinsci/account/ui/admin/AdminSearchPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/AdminSearchPage.java
@@ -1,9 +1,12 @@
 package org.jenkinsci.account.ui.admin;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 // page_url = http://localhost:8080/admin/search
 public class AdminSearchPage {
@@ -22,20 +25,27 @@ public class AdminSearchPage {
     @FindBy(xpath = "//input[@value=\"Delete\"]")
     private WebElement deleteUserButton;
 
-    public AdminSearchPage(WebDriver driver) {
+    private final WebDriverWait wait;
+
+    public AdminSearchPage(WebDriver driver, WebDriverWait wait) {
+        this.wait = wait;
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("confirm")));
         PageFactory.initElements(driver, this);
     }
 
     public void resetPassword() {
+        wait.until(ExpectedConditions.elementToBeClickable(resetPasswordButton));
         resetPasswordButton.click();
     }
 
     public void deleteUser() {
+        wait.until(ExpectedConditions.elementToBeClickable(confirmDeleteUserInput));
         confirmDeleteUserInput.sendKeys("Yes");
         deleteUserButton.click();
     }
 
     public void updateEmail(String newEmail) {
+        wait.until(ExpectedConditions.elementToBeClickable(updateEmailInput));
         updateEmailInput.sendKeys(newEmail);
         updateEmailButton.click();
     }

--- a/src/it/java/org/jenkinsci/account/ui/admin/DeleteUserTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/DeleteUserTest.java
@@ -5,6 +5,7 @@ import org.jenkinsci.account.ui.login.LoginPage;
 import org.jenkinsci.account.ui.myaccount.MyAccountPage;
 import org.jenkinsci.account.ui.resetpassword.UserLookupType;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,27 +23,28 @@ public class DeleteUserTest extends BaseTest {
 
     public void deleteUser(String username, String email, UserLookupType userLookupType) {
         openHomePage();
-        LoginPage loginPage = new LoginPage(driver);
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.login("kohsuke", "password");
 
-        MyAccountPage myAccountPage = new MyAccountPage(driver);
+        MyAccountPage myAccountPage = new MyAccountPage(driver, wait);
         myAccountPage.clickAdminLink();
 
-        AdminPage adminPage = new AdminPage(driver);
+        AdminPage adminPage = new AdminPage(driver, wait);
         if (userLookupType == UserLookupType.USERNAME) {
             adminPage.search(username);
         } else {
             adminPage.search(email);
         }
 
-        AdminSearchPage adminSearchPage = new AdminSearchPage(driver);
+        AdminSearchPage adminSearchPage = new AdminSearchPage(driver, wait);
         adminSearchPage.deleteUser();
         adminPage.verifyOnPage();
 
         newSession();
 
-        loginPage = new LoginPage(driver);
+        loginPage = new LoginPage(driver, wait);
         loginPage.login("alice", "password");
+        wait.until(ExpectedConditions.titleContains("Error"));
         assertThat(driver.getTitle()).isEqualTo("Error | Jenkins");
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/admin/ResetPasswordAdminTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/ResetPasswordAdminTest.java
@@ -10,6 +10,7 @@ import org.jenkinsci.account.ui.login.LoginPage;
 import org.jenkinsci.account.ui.myaccount.MyAccountPage;
 import org.jenkinsci.account.ui.resetpassword.UserLookupType;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,13 +28,13 @@ public class ResetPasswordAdminTest extends BaseTest {
 
     private void resetPassword(String username, String email, UserLookupType userLookupType) throws MessagingException, IOException {
         openHomePage();
-        LoginPage loginPage = new LoginPage(driver);
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.login("kohsuke", "password");
 
-        MyAccountPage myAccountPage = new MyAccountPage(driver);
+        MyAccountPage myAccountPage = new MyAccountPage(driver, wait);
         myAccountPage.clickAdminLink();
 
-        AdminPage adminPage = new AdminPage(driver);
+        AdminPage adminPage = new AdminPage(driver, wait);
         if (userLookupType == UserLookupType.USERNAME) {
             adminPage.search(username);
         } else {
@@ -42,10 +43,10 @@ public class ResetPasswordAdminTest extends BaseTest {
 
         Date timestampBeforeReset = new Date();
 
-        AdminSearchPage adminSearchPage = new AdminSearchPage(driver);
+        AdminSearchPage adminSearchPage = new AdminSearchPage(driver, wait);
         adminSearchPage.resetPassword();
 
-        AdminResetPasswordResultPage resetPasswordResultPage = new AdminResetPasswordResultPage(driver);
+        AdminResetPasswordResultPage resetPasswordResultPage = new AdminResetPasswordResultPage(driver, wait);
         String newPassword = resetPasswordResultPage.getNewPassword();
 
         String emailContent = READ_INBOUND_EMAIL_SERVICE
@@ -65,8 +66,8 @@ public class ResetPasswordAdminTest extends BaseTest {
 
         newSession();
 
-        new LoginPage(driver).login(username, newPassword);
-        String pageTitle = driver.getTitle();
-        assertThat(pageTitle).contains("Account");
+        new LoginPage(driver, wait).login(username, newPassword);
+        wait.until(ExpectedConditions.titleContains("Account"));
+        assertThat(driver.getTitle()).contains("Account");
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/login/LoginPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/login/LoginPage.java
@@ -4,6 +4,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 // page_url = http://localhost:8080/login
 public class LoginPage {
@@ -22,34 +24,29 @@ public class LoginPage {
     @FindBy(xpath = "//a[@href=\"signup\"]")
     private WebElement signupLink;
 
-    public LoginPage(WebDriver driver) {
+    private final WebDriverWait wait;
+
+    public LoginPage(WebDriver driver, WebDriverWait wait) {
+        this.wait = wait;
+        wait.until(ExpectedConditions.visibilityOfElementLocated(
+                org.openqa.selenium.By.name("userid")));
         PageFactory.initElements(driver, this);
     }
 
     public void login(String username, String password) {
-        enterUsername(username);
-        enterPassword(password);
-
-        clickLogin();
+        wait.until(ExpectedConditions.elementToBeClickable(usernameField));
+        usernameField.sendKeys(username);
+        passwordField.sendKeys(password);
+        loginBtn.click();
     }
 
     public void clickForgotPassword() {
+        wait.until(ExpectedConditions.elementToBeClickable(forgotPasswordLink));
         forgotPasswordLink.click();
     }
 
     public void clickSignup() {
+        wait.until(ExpectedConditions.elementToBeClickable(signupLink));
         signupLink.click();
-    }
-
-    private void enterUsername(String username) {
-        usernameField.sendKeys(username);
-    }
-
-    private void enterPassword(String password) {
-        passwordField.sendKeys(password);
-    }
-
-    private void clickLogin() {
-        loginBtn.click();
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/login/LoginTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/login/LoginTest.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.account.ui.login;
 
 import org.jenkinsci.account.ui.BaseTest;
-import org.jenkinsci.account.ui.login.LoginPage;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,11 +12,10 @@ class LoginTest extends BaseTest {
     void acceptsValidPassword() {
         openHomePage();
 
-        LoginPage loginPage = new LoginPage(driver);
-
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.login("alice", "password");
 
-        String pageTitle = driver.getTitle();
-        assertThat(pageTitle).contains("Account");
+        wait.until(ExpectedConditions.titleContains("Account"));
+        assertThat(driver.getTitle()).contains("Account");
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/myaccount/MyAccountPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/myaccount/MyAccountPage.java
@@ -1,10 +1,12 @@
 package org.jenkinsci.account.ui.myaccount;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import java.util.List;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 // page_url = http://localhost:8080/
 public class MyAccountPage {
@@ -14,15 +16,21 @@ public class MyAccountPage {
     @FindBy(xpath = "//a[@href=\"/myself\"]")
     private WebElement profileLink;
 
-    public MyAccountPage(WebDriver driver) {
+    private final WebDriverWait wait;
+
+    public MyAccountPage(WebDriver driver, WebDriverWait wait) {
+        this.wait = wait;
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@href=\"/myself\"]")));
         PageFactory.initElements(driver, this);
     }
 
     public void clickAdminLink() {
-       administerLink.click();
+        wait.until(ExpectedConditions.elementToBeClickable(administerLink));
+        administerLink.click();
     }
 
     public void clickProfileLink() {
+        wait.until(ExpectedConditions.elementToBeClickable(profileLink));
         profileLink.click();
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/myaccount/MyProfilePage.java
+++ b/src/it/java/org/jenkinsci/account/ui/myaccount/MyProfilePage.java
@@ -1,10 +1,12 @@
 package org.jenkinsci.account.ui.myaccount;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import java.util.List;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 // page_url = http://localhost:8080/myself/
 public class MyProfilePage {
@@ -35,7 +37,11 @@ public class MyProfilePage {
     @FindBy(xpath = "//button[@type=\"submit\"]")
     private WebElement updateButton;
 
-    public MyProfilePage(WebDriver driver) {
+    private final WebDriverWait wait;
+
+    public MyProfilePage(WebDriver driver, WebDriverWait wait) {
+        this.wait = wait;
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("firstName")));
         PageFactory.initElements(driver, this);
     }
 
@@ -68,7 +74,6 @@ public class MyProfilePage {
         updateOldPassword(oldPassword);
         updateNewPassword(newPassword);
         updateConfirmNewPassword(newPassword);
-
         updateButton.click();
     }
 

--- a/src/it/java/org/jenkinsci/account/ui/myaccount/UpdateMyAccountTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/myaccount/UpdateMyAccountTest.java
@@ -4,6 +4,7 @@ import org.jenkinsci.account.ui.BaseTest;
 import org.jenkinsci.account.ui.login.LoginPage;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,13 +14,13 @@ public class UpdateMyAccountTest extends BaseTest {
     public void updateProfileDetails() {
         openHomePage();
 
-        LoginPage loginPage = new LoginPage(driver);
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.login("alice", "password");
 
-        MyAccountPage myAccountPage = new MyAccountPage(driver);
+        MyAccountPage myAccountPage = new MyAccountPage(driver, wait);
         myAccountPage.clickProfileLink();
 
-        MyProfilePage profilePage = new MyProfilePage(driver);
+        MyProfilePage profilePage = new MyProfilePage(driver, wait);
         profilePage.updateFirstName("Kohsuke1");
         profilePage.updateLastName("Kawaguchi1");
         profilePage.updateEmail("kohsuke@jenkins-ci.org");
@@ -27,6 +28,7 @@ public class UpdateMyAccountTest extends BaseTest {
         profilePage.updateSSHKeys("abcdefgh");
         profilePage.update();
 
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.tagName("h1")));
         assertThat(driver.findElement(By.tagName("h1")).getText()).isEqualTo("Done!");
     }
 
@@ -35,59 +37,60 @@ public class UpdateMyAccountTest extends BaseTest {
     public void changePasswordValuesMustMatch() {
         openHomePage();
 
-        LoginPage loginPage = new LoginPage(driver);
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.login("alice", "password");
 
-        MyAccountPage myAccountPage = new MyAccountPage(driver);
+        MyAccountPage myAccountPage = new MyAccountPage(driver, wait);
         myAccountPage.clickProfileLink();
 
-        MyProfilePage profilePage = new MyProfilePage(driver);
+        MyProfilePage profilePage = new MyProfilePage(driver, wait);
         profilePage.updateOldPassword("password");
         profilePage.updateNewPassword("password1");
         profilePage.updateConfirmNewPassword("password2");
         profilePage.update();
 
-        String pageTitle = driver.getTitle();
-        assertThat(pageTitle).contains("Error");
+        wait.until(ExpectedConditions.titleContains("Error"));
+        assertThat(driver.getTitle()).contains("Error");
     }
 
     @Test
     public void changePasswordValuesMustProvideOldPassword() {
         openHomePage();
 
-        LoginPage loginPage = new LoginPage(driver);
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.login("alice", "password");
 
-        MyAccountPage myAccountPage = new MyAccountPage(driver);
+        MyAccountPage myAccountPage = new MyAccountPage(driver, wait);
         myAccountPage.clickProfileLink();
 
-        MyProfilePage profilePage = new MyProfilePage(driver);
+        MyProfilePage profilePage = new MyProfilePage(driver, wait);
         profilePage.updateNewPassword("password1");
         profilePage.updateConfirmNewPassword("password1");
         profilePage.update();
 
-        String pageTitle = driver.getTitle();
-        assertThat(pageTitle).contains("Error");
+        wait.until(ExpectedConditions.titleContains("Error"));
+        assertThat(driver.getTitle()).contains("Error");
     }
 
     @Test
     public void changePassword() {
         openHomePage();
 
-        LoginPage loginPage = new LoginPage(driver);
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.login("alice", "password");
 
-        MyAccountPage myAccountPage = new MyAccountPage(driver);
+        MyAccountPage myAccountPage = new MyAccountPage(driver, wait);
         myAccountPage.clickProfileLink();
 
-        MyProfilePage profilePage = new MyProfilePage(driver);
+        MyProfilePage profilePage = new MyProfilePage(driver, wait);
         profilePage.changePassword("password", "password1");
 
+        wait.until(org.openqa.selenium.support.ui.ExpectedConditions.titleContains("Account App"));
         newSession();
-        loginPage = new LoginPage(driver);
+        loginPage = new LoginPage(driver, wait);
         loginPage.login("alice", "password1");
 
-        String pageTitle = driver.getTitle();
-        assertThat(pageTitle).contains("Account");
+        wait.until(ExpectedConditions.titleContains("Account"));
+        assertThat(driver.getTitle()).contains("Account");
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordPage.java
@@ -5,7 +5,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import java.util.List;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 // page_url = http://localhost:8080/passwordReset
 public class ResetPasswordPage {
@@ -16,18 +17,23 @@ public class ResetPasswordPage {
     private WebElement resetPrimaryBlockButton;
 
     private final WebDriver driver;
+    private final WebDriverWait wait;
 
-    public ResetPasswordPage(WebDriver driver) {
-        PageFactory.initElements(driver, this);
+    public ResetPasswordPage(WebDriver driver, WebDriverWait wait) {
         this.driver = driver;
+        this.wait = wait;
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("id")));
+        PageFactory.initElements(driver, this);
     }
 
     public void resetPassword(String usernameOrEmail) {
+        wait.until(ExpectedConditions.elementToBeClickable(usernameOrEmailInput));
         usernameOrEmailInput.sendKeys(usernameOrEmail);
         resetPrimaryBlockButton.click();
     }
-    
+
     public String resultText() {
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("p")));
         return driver.findElement(By.cssSelector("p")).getText();
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordTest.java
@@ -8,6 +8,7 @@ import org.jenkinsci.account.ui.BaseTest;
 import org.jenkinsci.account.ui.email.Emails;
 import org.jenkinsci.account.ui.login.LoginPage;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,12 +27,12 @@ class ResetPasswordTest extends BaseTest {
     private void resetPassword(String username, String email, UserLookupType userLookupType) throws MessagingException, IOException {
         openHomePage();
 
-        LoginPage loginPage = new LoginPage(driver);
+        LoginPage loginPage = new LoginPage(driver, wait);
         loginPage.clickForgotPassword();
 
         Date timestampBeforeReset = new Date();
 
-        ResetPasswordPage resetPasswordPage = new ResetPasswordPage(driver);
+        ResetPasswordPage resetPasswordPage = new ResetPasswordPage(driver, wait);
         if (userLookupType == UserLookupType.USERNAME) {
             resetPasswordPage.resetPassword(username);
         } else {
@@ -57,9 +58,10 @@ class ResetPasswordTest extends BaseTest {
         String password = matcher.group(1);
 
         openHomePage();
+        loginPage = new LoginPage(driver, wait);
         loginPage.login(username, password);
 
-        String pageTitle = driver.getTitle();
-        assertThat(pageTitle).contains("Account");
+        wait.until(ExpectedConditions.titleContains("Account"));
+        assertThat(driver.getTitle()).contains("Account");
     }
 }


### PR DESCRIPTION
AI assisted PR.

1. --no-sandbox / --disable-dev-shm-usage missing — required when Chrome runs inside a Docker container without user namespace privileges.

2. No WebDriverWait anywhere — all page objects now wait for their landmark element to be visible before PageFactory.initElements(), and wait for elements to be clickable before interactions. All title assertions are preceded by wait.until(titleContains(...)).

3. changePassword test race — profilePage.changePassword() submitted the form but newSession() quit the driver immediately after the click. If the LDAP write hadn't completed before the next login, the password was still the old one. Fixed by waiting for titleContains("Account App") (the Myself/done.jelly title) before calling newSession().