### PR TITLE
Send email with reset token

### DIFF
--- a/src/it/java/org/jenkinsci/account/ui/admin/AdminResetPasswordResultPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/AdminResetPasswordResultPage.java
@@ -10,18 +10,18 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 // page_url = http://localhost:8080/admin/passwordReset
 public class AdminResetPasswordResultPage {
-    @FindBy(xpath = "//p/code")
-    private WebElement newPasswordText;
+    @FindBy(xpath = "//p[strong]")
+    private WebElement confirmationText;
 
     private final WebDriverWait wait;
 
     public AdminResetPasswordResultPage(WebDriver driver, WebDriverWait wait) {
         this.wait = wait;
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//p/code")));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//p/strong")));
         PageFactory.initElements(driver, this);
     }
 
-    public String getNewPassword() {
-        return newPasswordText.getText();
+    public String getConfirmationText() {
+        return confirmationText.getText();
     }
 }

--- a/src/it/java/org/jenkinsci/account/ui/admin/ResetPasswordAdminTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/admin/ResetPasswordAdminTest.java
@@ -8,6 +8,7 @@ import org.jenkinsci.account.ui.BaseTest;
 import org.jenkinsci.account.ui.email.Emails;
 import org.jenkinsci.account.ui.login.LoginPage;
 import org.jenkinsci.account.ui.myaccount.MyAccountPage;
+import org.jenkinsci.account.ui.resetpassword.ConfirmPasswordResetPage;
 import org.jenkinsci.account.ui.resetpassword.UserLookupType;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -46,8 +47,8 @@ public class ResetPasswordAdminTest extends BaseTest {
         AdminSearchPage adminSearchPage = new AdminSearchPage(driver, wait);
         adminSearchPage.resetPassword();
 
-        AdminResetPasswordResultPage resetPasswordResultPage = new AdminResetPasswordResultPage(driver, wait);
-        String newPassword = resetPasswordResultPage.getNewPassword();
+        AdminResetPasswordResultPage resultPage = new AdminResetPasswordResultPage(driver, wait);
+        assertThat(resultPage.getConfirmationText()).contains(email);
 
         String emailContent = READ_INBOUND_EMAIL_SERVICE
                 .retrieveEmail(
@@ -56,15 +57,20 @@ public class ResetPasswordAdminTest extends BaseTest {
                         timestampBeforeReset
                 );
 
-        Matcher matcher = Emails.PASSWORD_EXTRACTOR.matcher(emailContent);
-        boolean matches = matcher.find();
-        assertThat(matches).isTrue();
+        assertThat(emailContent).isNotEmpty();
 
-        String passwordFromEmail = matcher.group(1);
+        Matcher matcher = Emails.RESET_LINK_EXTRACTOR.matcher(emailContent);
+        assertThat(matcher.find()).isTrue();
 
-        assertThat(newPassword).isEqualTo(passwordFromEmail);
+        String resetLink = matcher.group(1);
 
         newSession();
+
+        driver.get(resetLink);
+
+        String newPassword = "newSecurePass99";
+        ConfirmPasswordResetPage confirmPage = new ConfirmPasswordResetPage(driver);
+        confirmPage.setNewPassword(newPassword, newPassword);
 
         new LoginPage(driver, wait).login(username, newPassword);
         wait.until(ExpectedConditions.titleContains("Account"));

--- a/src/it/java/org/jenkinsci/account/ui/email/Emails.java
+++ b/src/it/java/org/jenkinsci/account/ui/email/Emails.java
@@ -4,7 +4,8 @@ import java.util.regex.Pattern;
 
 public class Emails {
 
-    public static final Pattern PASSWORD_EXTRACTOR = Pattern.compile("Your temporary password is ([a-zA-Z0-9]+)");
+    public static final Pattern RESET_LINK_EXTRACTOR =
+            Pattern.compile("(https?://\\S+confirmPasswordReset\\?token=[A-Za-z0-9_=-]+)");
 
     public static final String RESET_PASSWORD_SUBJECT = "Password reset on the Jenkins project infrastructure";
 }

--- a/src/it/java/org/jenkinsci/account/ui/resetpassword/ConfirmPasswordResetPage.java
+++ b/src/it/java/org/jenkinsci/account/ui/resetpassword/ConfirmPasswordResetPage.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.account.ui.resetpassword;
+
+import java.time.Duration;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+// page_url = http://localhost:8080/confirmPasswordReset?token=...
+public class ConfirmPasswordResetPage {
+    @FindBy(name = "newPassword1")
+    private WebElement newPasswordInput;
+
+    @FindBy(name = "newPassword2")
+    private WebElement confirmPasswordInput;
+
+    @FindBy(xpath = "//button[@type='submit']")
+    private WebElement submitButton;
+
+    private final WebDriver driver;
+
+    public ConfirmPasswordResetPage(WebDriver driver) {
+        this.driver = driver;
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.visibilityOfElementLocated(By.name("newPassword1")));
+        PageFactory.initElements(driver, this);
+    }
+
+    public void setNewPassword(String password, String confirm) {
+        newPasswordInput.sendKeys(password);
+        confirmPasswordInput.sendKeys(confirm);
+        submitButton.click();
+        // Wait for the form submission to complete and redirect to login
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.not(
+                        ExpectedConditions.urlContains("confirmPasswordReset")));
+    }
+}

--- a/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordTest.java
+++ b/src/it/java/org/jenkinsci/account/ui/resetpassword/ResetPasswordTest.java
@@ -51,15 +51,20 @@ class ResetPasswordTest extends BaseTest {
 
         assertThat(emailContent).isNotEmpty();
 
-        Matcher matcher = Emails.PASSWORD_EXTRACTOR.matcher(emailContent);
-        boolean matches = matcher.find();
-        assertThat(matches).isTrue();
+        Matcher matcher = Emails.RESET_LINK_EXTRACTOR.matcher(emailContent);
+        assertThat(matcher.find()).isTrue();
 
-        String password = matcher.group(1);
+        String resetLink = matcher.group(1);
+
+        driver.get(resetLink);
+
+        String newPassword = "newSecurePass42";
+        ConfirmPasswordResetPage confirmPage = new ConfirmPasswordResetPage(driver);
+        confirmPage.setNewPassword(newPassword, newPassword);
 
         openHomePage();
         loginPage = new LoginPage(driver, wait);
-        loginPage.login(username, password);
+        loginPage.login(username, newPassword);
 
         wait.until(ExpectedConditions.titleContains("Account"));
         assertThat(driver.getTitle()).contains("Account");

--- a/src/main/java/org/jenkinsci/account/AdminUI.java
+++ b/src/main/java/org/jenkinsci/account/AdminUI.java
@@ -2,10 +2,10 @@ package org.jenkinsci.account;
 
 import jakarta.mail.MessagingException;
 import org.jenkinsci.account.Application.User;
+import org.jenkinsci.account.PasswordResetTokenService;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.naming.NamingException;
@@ -57,15 +57,15 @@ public class AdminUI {
         LdapContext con = app.connect();
         try {
             User u = app.getUserById(id, con);
-
-            String p = PasswordUtil.generateRandomPassword();
-            u.modifyPassword(con, p);
-            u.mailPasswordReset(p, Stapler.getCurrentRequest().getRemoteUser(), reason);
+            u.modifyPassword(con, PasswordUtil.generateRandomPassword());
+            String token = app.resetTokenService.createToken(u.id, PasswordResetTokenService.RESET_TTL);
+            u.mailAdminPasswordResetLink(token);
+            LOGGER.info("Admin triggered password reset for " + u.id + " (reason: " + reason + ")");
 
             if (Myself.current().isAuthenticatedWithREST()) {
                 return HttpResponses.ok();
             } else {
-                return HttpResponses.forwardToView(this,"newPassword.jelly").with("user", u).with("password", p);
+                return HttpResponses.forwardToView(this, "passwordResetSent.jelly").with("user", u);
             }
         } finally {
             con.close();
@@ -110,9 +110,12 @@ public class AdminUI {
             @QueryParameter boolean skipPassword,
             @QueryParameter String message
     ) throws NamingException, MessagingException {
-        String password = app.createRecord(userid, firstName, lastName, email);
+        app.createRecord(userid, firstName, lastName, email);
 
-        app.new User(userid,email).mailAccountCreated(!skipPassword, password, message);
+        if (!skipPassword) {
+            String token = app.resetTokenService.createToken(userid, PasswordResetTokenService.ACTIVATION_TTL);
+            app.new User(userid, email).mailAccountCreatedWithLink(token, message);
+        }
 
         return HttpResponses.plainText("Created");
     }

--- a/src/main/java/org/jenkinsci/account/Application.java
+++ b/src/main/java/org/jenkinsci/account/Application.java
@@ -83,10 +83,13 @@ public class Application {
     // not exposing this to UI
     /*package*/ final CircuitBreaker circuitBreaker;
 
+    public final PasswordResetTokenService resetTokenService;
+
     public Application(Parameters params) throws Exception {
         this.params = params;
         this.openid = new JenkinsOpenIDServer(this);
         this.circuitBreaker = new CircuitBreaker(params);
+        this.resetTokenService = new PasswordResetTokenService();
     }
 
     public String getUrl() {
@@ -221,12 +224,13 @@ public class Application {
             throw new SystemError(SPAM_MESSAGE);
         }
 
-        String password = createRecord(userid, firstName, lastName, email);
+        createRecord(userid, firstName, lastName, email);
         LOGGER.info("User "+userid+" is from "+ip);
         mail("jenkinsci-account-admins@googlegroups.com", "New user created for " + userid,
             userDetails + "\n\nHTTP Headers\n" +
                 dumpHeaders(request) + "\n\n" + "Account page: " + getUrl() + "/admin/search?word=" + userid + "\n\nIP Void link: http://ipvoid.com/scan/" + ip + "/\n", "text/plain");
-        new User(userid,email).mailPassword(password);
+        String token = resetTokenService.createToken(userid, PasswordResetTokenService.ACTIVATION_TTL);
+        new User(userid,email).mailActivationLink(token);
 
         Cookie cookie = new Cookie(ALREADY_SIGNED_UP, "1");
         cookie.setDomain("accounts.jenkins.io");
@@ -330,28 +334,57 @@ public class Application {
     }
 
     /**
-     * Handles the password reset form submission.
+     * Handles the "Forgot password" form submission.
+     * Issues a time-limited token and emails a reset link — does NOT change the current password.
      */
     @RequirePOST
-    public HttpResponse doDoPasswordReset(@QueryParameter String id, @QueryParameter String reason) throws Exception {
-        final DirContext con = connect();
-        if (id.isEmpty())
+    public HttpResponse doDoPasswordReset(@QueryParameter String id) throws Exception {
+        if (id == null || id.isEmpty())
             throw new UserError("No email or user account provided");
+        final DirContext con = connect();
         try {
             Iterator<User> a = searchByWord(id, con);
             if (a.hasNext()) {
                 User u = a.next();
-
-                String p = PasswordUtil.generateRandomPassword();
-                u.modifyPassword(con, p);
-                u.mailPasswordReset(p, Stapler.getCurrentRequest().getRemoteUser(),
-                    StringUtils.isBlank(reason) ? "request in the account management app" : reason );
+                String token = resetTokenService.createToken(u.id, PasswordResetTokenService.RESET_TTL);
+                u.mailPasswordResetLink(token);
             }
         } finally {
             con.close();
         }
-
         return new HttpRedirect("resetMail");
+    }
+
+    /**
+     * Shows the "set new password" form after the user clicks the reset link in their email.
+     */
+    public HttpResponse doConfirmPasswordReset(@QueryParameter String token) {
+        resetTokenService.validateToken(token);
+        return HttpResponses.forwardToView(this, "confirmPasswordReset.jelly").with("token", token);
+    }
+
+    /**
+     * Applies the new password chosen by the user after validating the reset token.
+     */
+    @RequirePOST
+    public HttpResponse doDoConfirmPasswordReset(
+            @QueryParameter String token,
+            @QueryParameter String newPassword1,
+            @QueryParameter String newPassword2) throws Exception {
+        if (newPassword1 == null || newPassword1.isEmpty())
+            throw new UserError("New password is required");
+        if (newPassword1.length() < 8)
+            throw new UserError("Password must be at least 8 characters long.");
+        if (!newPassword1.equals(newPassword2))
+            throw new UserError("Passwords do not match");
+        String userId = resetTokenService.validateAndConsumeToken(token);
+        final DirContext con = connect();
+        try {
+            getUserById(userId, con).modifyPassword(con, newPassword1);
+        } finally {
+            con.close();
+        }
+        return new HttpRedirect("login");
     }
 
     public User getUserById(String id, DirContext con) throws NamingException {
@@ -397,41 +430,56 @@ public class Application {
         }
 
         /**
-         * Sends a new password to this user.
+         * Emails a one-time account activation link after self-signup.
          */
-        public void mailPassword(String password) throws MessagingException {
-            mail(mail, "Your access to Jenkins resources", "Your userid is " + id + "\n" +
-                "Your temporary password is " + password + "\n" +
-                "\n" +
-                "Please visit " + getUrl() + " and update your password and profile\n", "text/plain");
-        }
-
-        /**
-         * Sends a new password to this user.
-         */
-        public void mailAccountCreated(boolean sendPassword, String password, @CheckForNull String message) throws MessagingException {
-            mail(mail, "New account on the Jenkins project infrastructure",
-                "Dear recipient, \n\n" +
-                "We have created a new Jenkins project account for you. Your new user ID is " + id + "\n" +
-                ( sendPassword ? "Your temporary password is " + password + "\n" : "" ) +
-                ( StringUtils.isNotBlank(message) ? message + "\n" : "" ) +
-                "\n" +
-                ( sendPassword ? "Please visit " + getUrl() + " and update your password and profile\n" : "" ), 
+        public void mailActivationLink(String token) throws MessagingException {
+            String link = getUrl() + "confirmPasswordReset?token=" + token;
+            mail(mail, "Your access to Jenkins resources",
+                "Your Jenkins account has been created. Your userid is " + id + "\n\n" +
+                "Click the following link to set your password and activate your account. The link expires in 24 hours:\n" +
+                link + "\n",
                 "text/plain");
         }
 
         /**
-         * Sends a new password and a password reset notification to this user.
+         * Emails a one-time account activation link for admin-created accounts.
          */
-        public void mailPasswordReset(String password, @CheckForNull String requestedByUser, @CheckForNull String reason) throws MessagingException {
+        public void mailAccountCreatedWithLink(String token, @CheckForNull String message) throws MessagingException {
+            String link = getUrl() + "confirmPasswordReset?token=" + token;
+            mail(mail, "New account on the Jenkins project infrastructure",
+                "Dear recipient,\n\n" +
+                "We have created a new Jenkins project account for you. Your new user ID is " + id + "\n" +
+                (StringUtils.isNotBlank(message) ? message + "\n" : "") +
+                "\nClick the following link to set your password. The link expires in 24 hours:\n" +
+                link + "\n",
+                "text/plain");
+        }
+
+        /**
+         * Emails a one-time password reset link for a user-initiated reset.
+         * Does not change or reveal the current password.
+         */
+        public void mailPasswordResetLink(String token) throws MessagingException {
+            String link = getUrl() + "confirmPasswordReset?token=" + token;
             mail(mail, "Password reset on the Jenkins project infrastructure",
-                "Your Jenkins account password was reset. " +
-                (requestedByUser != null ? String.format("It was requested by user %s. ", requestedByUser) : "") +
-                (StringUtils.isNotBlank(reason) ? String.format("Reason: %s. ", reason) : "") +
-                "Your userid is " + id + "\n" +
-                "Your temporary password is " + password + "\n" +
-                "\n" +
-                "Please visit " + getUrl() + " and update your password and profile\n", "text/plain");
+                "A password reset was requested for your Jenkins account (userid: " + id + ").\n\n" +
+                "Click the following link to set a new password. The link expires in 1 hour:\n" +
+                link + "\n\n" +
+                "If you did not request this, you can safely ignore this email — your current password has not been changed.\n",
+                "text/plain");
+        }
+
+        /**
+         * Emails a one-time password reset link for an admin-initiated reset.
+         * The previous password has already been invalidated.
+         */
+        public void mailAdminPasswordResetLink(String token) throws MessagingException {
+            String link = getUrl() + "confirmPasswordReset?token=" + token;
+            mail(mail, "Password reset on the Jenkins project infrastructure",
+                "An administrator has reset the password for your Jenkins account (userid: " + id + ").\n\n" +
+                "Your previous password has been invalidated. Click the following link to set a new password. The link expires in 1 hour:\n" +
+                link + "\n",
+                "text/plain");
         }
 
         public void delete(DirContext con) throws NamingException {

--- a/src/main/java/org/jenkinsci/account/PasswordResetTokenService.java
+++ b/src/main/java/org/jenkinsci/account/PasswordResetTokenService.java
@@ -1,0 +1,57 @@
+package org.jenkinsci.account;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PasswordResetTokenService {
+    public static final Duration RESET_TTL = Duration.ofHours(1);
+    public static final Duration ACTIVATION_TTL = Duration.ofHours(24);
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private record TokenRecord(String userId, Instant expiresAt) {}
+
+    private final ConcurrentHashMap<String, TokenRecord> tokenStore = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> userToToken = new ConcurrentHashMap<>();
+
+    public String createToken(String userId, Duration ttl) {
+        byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        String token = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        String oldToken = userToToken.get(userId);
+        if (oldToken != null) tokenStore.remove(oldToken);
+        tokenStore.put(token, new TokenRecord(userId, Instant.now().plus(ttl)));
+        userToToken.put(userId, token);
+        return token;
+    }
+
+    public String validateToken(String token) {
+        if (token == null) throw new UserError("Invalid or expired link.");
+        TokenRecord r = tokenStore.get(token);
+        if (r == null || Instant.now().isAfter(r.expiresAt())) {
+            if (r != null) {
+                tokenStore.remove(token);
+                userToToken.remove(r.userId(), token);
+            }
+            throw new UserError("This link is invalid or has expired. Please request a new one.");
+        }
+        return r.userId();
+    }
+
+    /**
+     * Atomically consumes and validates the token. Only one concurrent caller can succeed;
+     * subsequent calls with the same token get the invalid-or-expired error.
+     */
+    public String validateAndConsumeToken(String token) {
+        if (token == null) throw new UserError("Invalid or expired link.");
+        TokenRecord r = tokenStore.remove(token);
+        if (r == null || Instant.now().isAfter(r.expiresAt())) {
+            throw new UserError("This link is invalid or has expired. Please request a new one.");
+        }
+        userToToken.remove(r.userId());
+        return r.userId();
+    }
+}

--- a/src/main/resources/org/jenkinsci/account/AdminUI/newPassword.jelly
+++ b/src/main/resources/org/jenkinsci/account/AdminUI/newPassword.jelly
@@ -1,8 +1,0 @@
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:t="/org/jenkinsci/account/taglib">
-  <t:layout title="Password reset">
-    <p>
-      The password of ${user.id} (${user.mail}) is reset to: <code>${password}</code>
-    </p>
-  </t:layout>
-</j:jelly>

--- a/src/main/resources/org/jenkinsci/account/AdminUI/passwordResetSent.jelly
+++ b/src/main/resources/org/jenkinsci/account/AdminUI/passwordResetSent.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/org/jenkinsci/account/taglib">
+  <t:layout title="Password reset initiated">
+    <h1>Password reset link sent</h1>
+    <p>A password reset link has been emailed to <strong>${user.mail}</strong> (account: ${user.id}). The link expires in 1 hour.</p>
+    <p><a href="/admin">Back to Admin</a></p>
+  </t:layout>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/account/Application/confirmPasswordReset.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/confirmPasswordReset.jelly
@@ -1,0 +1,19 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/org/jenkinsci/account/taglib">
+  <t:layout title="Set new password" class="ac-small-width">
+    <h1>Set new password</h1>
+    <form method="post" action="doConfirmPasswordReset">
+      <input type="hidden" name="crumb" value="${app.crumb}"/>
+      <input type="hidden" name="token" value="${token}"/>
+      <div class="ac-form-group">
+        <label>New password</label>
+        <input autocomplete="new-password" type="password" name="newPassword1" class="form-control text" required="required"/>
+      </div>
+      <div class="ac-form-group">
+        <label>Confirm new password</label>
+        <input autocomplete="new-password" type="password" name="newPassword2" class="form-control text" required="required"/>
+      </div>
+      <button type="submit" class="app-button app-button--primary ac-button--large">Set password</button>
+    </form>
+  </t:layout>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/account/Application/doneMail.jelly
+++ b/src/main/resources/org/jenkinsci/account/Application/doneMail.jelly
@@ -3,9 +3,9 @@
   <t:layout title="Account created">
     <h1>Account created</h1>
     <p>
-      Check your email for the password.
-      You can log in to <a href="https://issues.jenkins.io/" target="_blank">Jira</a> and <a href="https://repo.jenkins-ci.org/" target="_blank">Artifactory</a>,
-      with this username and password.
+      Check your email for a link to set your password.
+      You can then log in to <a href="https://issues.jenkins.io/" target="_blank">Jira</a> and <a href="https://repo.jenkins-ci.org/" target="_blank">Artifactory</a>
+      with your username and password.
     </p>
   </t:layout>
 </j:jelly>


### PR DESCRIPTION
It's awkward that currently, "forgot password" will immediately invalidate the existing password and send a new one via email.

This PR changes behavior to the standard approach of sending only a password reset link that's valid for an hour, which allows setting a new password for that account.

When an admin resets a password, the current password is invalidated (more specifically, we generate a new password, but do not tell anyone). This allows admins to require a password reset by the user.

Largely vibecoded; manually tested with `docker-compose`.