### PR TITLE
chore(Jenkinsfile) ensure we always use a x86_64 VM to allow Selenium execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ pipeline {
         JAVA_HOME = '/opt/jdk-17'
     }
     agent {
-        // Integration tests requires an x86_64 CPU (Selenium) VM (no sandbox)
-        label 'linux-amd64-docker'
+        // Integration tests requires an x86_64 CPU (Selenium) but can run inside a container
+        label 'maven-17 || jnlp-linux-amd64'
     }
     options {
         disableConcurrentBuilds(abortPrevious: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,12 @@
+// Integration tests requires an x86_64 CPU for Selenium. A VM is required at least in infra.ci (AKS does not fare well with chromium (sandbox?) compared to EKS).
+final String agentLabel = infra.isInfra() ? 'linux-amd64-docker' : 'linux-amd64'
+
 pipeline {
     environment {
         JAVA_HOME = '/opt/jdk-17'
     }
     agent {
-        // Integration tests requires an x86_64 CPU (Selenium) but can run inside a container
-        label 'maven-17 || jnlp-linux-amd64'
+        label agentLabel
     }
     options {
         disableConcurrentBuilds(abortPrevious: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ pipeline {
         JAVA_HOME = '/opt/jdk-17'
     }
     agent {
-        // infra.ci build on amd64 to be compliant with selenium
-        label 'jdk17 || linux-amd64-docker '
+        // Integration tests requires an x86_64 CPU (Selenium) VM (no sandbox)
+        label 'linux-amd64-docker'
     }
     options {
         disableConcurrentBuilds(abortPrevious: true)


### PR DESCRIPTION
- Using an `arm64` VM (both on ci.jenkins.io AWS EC2 and infra.ci.jenkins.io Azure VM agents) results in integration tests failure as Selenium fails to spin up the Chromium instance (wehter its own or the pre-installed one)
- Using a container in infra.ci.jenkins.io (AKS) also fails (the Chromium process is immediately killed)
- Coherency (e.g. using an x86_64 VM) is better to avoid shift between CI and CD