### PR TITLE
chore(dockerfile): revert 76c6ec5 and ignore `DL3066` hadolint rule instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ ENV APP_URL=http://accounts.jenkins.io/
 
 EXPOSE 8080
 
-ARG ROOT_UID=0
-USER $ROOT_UID
+# hadolint ignore=DL3066
+USER root
 
 # /home/jetty/.app is apparently needed by Stapler for some weird reason. O_O
 RUN \
@@ -42,7 +42,7 @@ RUN chmod 0755 /entrypoint.sh &&\
 
 COPY circuitBreaker.txt /etc/accountapp/circuitBreaker.txt
 
-ARG JETTY_UID=999
-USER $JETTY_UID
+# hadolint ignore=DL3066
+USER jetty
 
 ENTRYPOINT ["bash","/entrypoint.sh"]


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/account-app/pull/523#discussion_r3819197975